### PR TITLE
add missing include

### DIFF
--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -60,6 +60,7 @@
 #include "device/usbd.h"
 #include "device/usbd_pvt.h"
 
+#include "tusb.h"
 #include "ump_device.h"
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Add missing include to `tusb.h` to fix version dependent `usbd_class_driver_t` instance.