### PR TITLE
Fix multi-instance UMP routing bugs in umpd_open()/umpd_control_xfer_cb()

### DIFF
--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -1042,7 +1042,26 @@ bool umpd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
   // nothing to with DATA & ACK stage
   if (stage != CONTROL_STAGE_SETUP) return true;
 
-  umpd_interface_t* ump = &_umpd_itf[rhport];
+  // Interface-addressed requests (SET_INTERFACE, GTB GET_DESCRIPTOR) carry the
+  // target interface number in wIndex -- resolve the matching UMP instance by
+  // itf_num, same pattern umpd_xfer_cb() already uses (matched by endpoint
+  // address there instead). Previously this indexed _umpd_itf[rhport], which
+  // is the USB controller/root-hub-port index, not an interface instance --
+  // always resolved to instance 0 regardless of which interface the host
+  // actually addressed. Harmless when CFG_TUD_UMP==1 (single instance, its
+  // itf_num always matches), but silently misrouted every SET_INTERFACE/GTB
+  // request for instance 1+ when CFG_TUD_UMP>1.
+  uint8_t itf_num = tu_u16_low(request->wIndex);
+  umpd_interface_t* ump = NULL;
+  for (uint8_t i = 0; i < CFG_TUD_UMP; i++)
+  {
+    if (_umpd_itf[i].itf_num == itf_num)
+    {
+      ump = &_umpd_itf[i];
+      break;
+    }
+  }
+  TU_VERIFY(ump);
 
   switch ( request->bRequest )
   {

--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -974,8 +974,59 @@ uint16_t umpd_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint1
     p_desc   = tu_desc_next(p_desc);
   }
 
-  // See if there is an alternate interface for UMP USB MIDI 2.0
-  if ( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) ) drv_len = max_len;
+  // See if there is an alternate interface for UMP USB MIDI 2.0 (bAlternateSetting 1,
+  // same bInterfaceNumber) immediately following. Previously this collapsed to
+  // `drv_len = max_len` -- "nothing more to parse in the whole config descriptor" --
+  // which only held when this was the sole USB MIDI Function (CFG_TUD_UMP == 1). With
+  // a second Function's IAD/interfaces following in the same config descriptor, that
+  // shortcut silently swallowed them: TinyUSB's core driver-dispatch loop believed
+  // umpd_open() had consumed everything and never called it again for instance 1+,
+  // so the second Function's endpoints were never opened and its itf_num never
+  // registered -- any SET_INTERFACE/GTB request addressed to it then failed
+  // TU_VERIFY(ump) in umpd_control_xfer_cb and STALLed (macOS logs "Unable to set
+  // MIDI 2.0 alt setting!" for that interface). Walk the alt setting's own
+  // descriptor block instead, same pattern as Alternate Setting 0 above, so drv_len
+  // correctly reflects only what this interface consumes. Its endpoint descriptors
+  // reuse Alt 0's addresses (USB MIDI 2.0 Alt-Setting model), so we measure their
+  // length without calling usbd_edpt_open() again.
+  while ( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) && drv_len <= max_len )
+  {
+    tusb_desc_interface_t const * desc_alt = (tusb_desc_interface_t const *) p_desc;
+    if ( desc_alt->bInterfaceNumber != desc_ump->bInterfaceNumber ) break; // next Function's interface, not an alt setting of this one
+
+    drv_len += tu_desc_len(p_desc);
+    p_desc   = tu_desc_next(p_desc);
+
+    // Skip class-specific descriptors (MS Header etc)
+    while ( TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && drv_len <= max_len )
+    {
+      drv_len += tu_desc_len(p_desc);
+      p_desc   = tu_desc_next(p_desc);
+    }
+
+    // Skip this alt setting's endpoint descriptors (+ their class-specific descriptors)
+    uint8_t alt_found_endpoints = 0;
+    while ( (alt_found_endpoints < desc_alt->bNumEndpoints) && (drv_len <= max_len) )
+    {
+      if ( TUSB_DESC_ENDPOINT == tu_desc_type(p_desc) )
+      {
+        // Same endpoint address as Alternate Setting 0 -- already opened, do not reopen
+        drv_len += tu_desc_len(p_desc);
+        p_desc   = tu_desc_next(p_desc);
+        alt_found_endpoints += 1;
+      }
+
+      drv_len += tu_desc_len(p_desc);
+      p_desc   = tu_desc_next(p_desc);
+    }
+
+    // Finish off any further class specific definitions for this alt setting
+    while ( TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && drv_len <= max_len )
+    {
+      drv_len += tu_desc_len(p_desc);
+      p_desc   = tu_desc_next(p_desc);
+    }
+  }
 
   // Prepare for incoming data
   _prep_out_transaction(p_ump);


### PR DESCRIPTION
## Summary

Fix two bugs that only affect devices exposing more than one USB MIDI Function (`CFG_TUD_UMP > 1`). Both bugs are invisible with the default single-instance configuration, which is why they went unnoticed.

- **`umpd_open()`** incorrectly skipped over the remainder of the MIDIStreaming interface's descriptor block after detecting Alternate Setting 1 (MIDI 2.0). That only works when there's a single USB MIDI Function. With additional Functions in the same configuration descriptor, TinyUSB believed the rest of the descriptor had already been consumed and never called `umpd_open()` for subsequent instances, leaving their endpoints unopened and their `itf_num` values unregistered.

- **`umpd_control_xfer_cb()`** used `_umpd_itf[rhport]` to resolve the target UMP instance. `rhport` identifies the USB controller, not the interface being addressed. Interface-directed requests such as `SET_INTERFACE` and the GTB `GET_DESCRIPTOR` request should instead be dispatched using the interface number from `wIndex`. With multiple USB MIDI Functions, every request was incorrectly routed to instance 0.

These issues were found while bringing up a composite device with two USB MIDI Functions. Before this change, the second Function never finished initialization and interface-directed requests to it failed, causing the host to reject MIDI 2.0 negotiation. After the fix, both Functions initialize correctly and interface-directed requests are routed to the intended instance.

This change only fixes the device-side implementation. In testing, macOS still negotiated MIDI 2.0 for only one USB MIDI Function per composite device, which appears to be a separate `AppleMIDIUSBDriver` limitation.

## Test plan

- [x] Verified the existing single-instance configuration (`CFG_TUD_UMP == 1`) still enumerates and negotiates MIDI 2.0 correctly on real hardware (tested with a MIDI + CDC composite device)
- [x] Verified a two-instance configuration (`CFG_TUD_UMP == 2`) on real hardware:
  - both USB MIDI Functions open their endpoints successfully
  - both correctly register their `itf_num`
  - interface-directed requests are dispatched to the correct instance regardless of which interface is addressed
  - confirmed via live firmware state (`_umpd_itf[].ump_interface_selected`) across two independent test builds
- [ ] Not verified (and not expected to pass without host-side changes): simultaneous MIDI 2.0 negotiation on both USB MIDI Functions. In every test run, macOS sent `SET_INTERFACE` for only one interface while leaving the other at Alternate Setting 0. Which interface was selected varied between runs, suggesting a host-side `AppleMIDIUSBDriver` limitation rather than a device-side issue.