### PR TITLE
Fix legacy MIDI1->UMP read overflowing caller's buffer

### DIFF
--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -348,7 +348,6 @@ static uint16_t tud_ump_read_impl( uint8_t itf, uint32_t *pkts, uint16_t numAvai
 {
   umpd_interface_t* ump = &_umpd_itf[itf];
   uint16_t numRead = 0;
-  uint16_t numProcessed = 0;
 
   static UMP_PACKET umpPacket;
 
@@ -357,8 +356,12 @@ static uint16_t tud_ump_read_impl( uint8_t itf, uint32_t *pkts, uint16_t numAvai
   // Determine if MIDI 1
   if (!ump->ump_interface_selected)
   {
-    // Always look for enough space to process in a SYSEX message
-    while ((numAvail - numProcessed) >= 2)
+    // Always look for enough space to process in a SYSEX message. Each raw
+    // USB-MIDI1 word can convert to up to 2 UMP words (a 64-bit SYSEX7
+    // packet), so bound the loop against remaining output space
+    // (numAvail - numRead) rather than remaining input words, to avoid
+    // overflowing the caller's buffer.
+    while ((numAvail - numRead) >= 2)
     {
       // Get next word from USB
       uint32_t readWord;
@@ -366,7 +369,6 @@ static uint16_t tud_ump_read_impl( uint8_t itf, uint32_t *pkts, uint16_t numAvai
       {
         goto END_READ;
       }
-      numProcessed++;
       //readWord = RtlUlongByteSwap(readWord);
 
       if (readWord)


### PR DESCRIPTION
## Summary
- `tud_ump_read_impl()`'s alt-0 (MIDI 1) branch bounded the read loop against the number of raw USB-MIDI1 words consumed (`numAvail - numProcessed`), not the number of converted UMP words written.
- Each raw word can convert to up to 2 UMP words (a 64-bit SYSEX7 packet), so the loop could keep consuming input after the output buffer was already full, writing past `numAvail` words into the caller's buffer.
- Bound the loop against remaining output space (`numAvail - numRead`) instead, so it never converts more input than there is room to write.

Fixes #15

## Test plan
- [ ] Re-run the `examples/tusb_ump_lb` loopback example on real hardware (RP2040/ProtoZOA) and confirm requesting 4 words during a SysEx completion no longer writes past the 4-word buffer.