### PR TITLE
Peek CIN to avoid stalling 1-word MIDI1 reads on a full-ish buffer

### DIFF
--- a/examples/tusb_ump_lb/src/main.c
+++ b/examples/tusb_ump_lb/src/main.c
@@ -62,15 +62,7 @@ int main(void)
         // time, echoing each straight back out.
         while (tud_ump_n_mounted(0) && tud_ump_n_available(0))
         {
-            // NOTE: buffer is oversized relative to the 4-word request below.
-            // On the legacy MIDI 1.0 byte stream alt setting (0),
-            // tud_ump_read_ntoh() can currently write up to ~2x the numAvail
-            // it's asked for when converting SysEx7 (known upstream
-            // ump_device.cpp bug: it bounds raw USB words consumed, not
-            // converted UMP words written). Requesting 4 but sizing the
-            // buffer for 8 absorbs that overrun without corrupting the
-            // stack; it does not fix the underlying bug.
-            uint32_t words[8];
+            uint32_t words[4];
             uint16_t count = tud_ump_read_ntoh(0, words, 4);
 
             if (count == 0)

--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -333,8 +333,10 @@ uint8_t tud_alt_setting( uint8_t itf) {
  * @param itf       interface number
  * @param pkts      Array of 32 bit formatted UMP packet data.
  * @param numAvail  Number of 32 bit UMP words that are available in handle
- *                  to populate. Note to accomodate possible SYSEX, needs to be at least 2
- *                  for 64bit size UMP Packet.
+ *                  to populate. A pending SYSEX-producing word (64-bit UMP
+ *                  packet) is only converted once 2 words of space remain;
+ *                  it is otherwise deferred to the next call rather than
+ *                  overflowing the buffer.
  * @param hostOrder If true, each returned word is the host-native uint32_t
  *                  whose arithmetic value matches the UMP wire word (bits
  *                  31:28 = message type, etc, per the MIDI 2.0 UMP spec) --
@@ -348,7 +350,6 @@ static uint16_t tud_ump_read_impl( uint8_t itf, uint32_t *pkts, uint16_t numAvai
 {
   umpd_interface_t* ump = &_umpd_itf[itf];
   uint16_t numRead = 0;
-  uint16_t numProcessed = 0;
 
   static UMP_PACKET umpPacket;
 
@@ -357,16 +358,43 @@ static uint16_t tud_ump_read_impl( uint8_t itf, uint32_t *pkts, uint16_t numAvai
   // Determine if MIDI 1
   if (!ump->ump_interface_selected)
   {
-    // Always look for enough space to process in a SYSEX message
-    while ((numAvail - numProcessed) >= 2)
+    // Loop while there's at least 1 free output slot. A raw USB-MIDI1 word
+    // converts to either 1 UMP word (Channel Voice, System Common) or 2 (a
+    // 64-bit SYSEX7 packet), so peek the next word's CIN first and only
+    // require 2 free slots when it's SYSEX-producing -- this bounds output
+    // against numAvail without needlessly stalling on 1-word messages when
+    // only 1 slot remains.
+    while ((numAvail - numRead) >= 1)
     {
+      uint8_t peekBuf[2];
+      if (tu_fifo_peek_n(&ump->rx_ff, peekBuf, sizeof(peekBuf)) != sizeof(peekBuf))
+      {
+        goto END_READ;
+      }
+
+      // Mirror tud_USBMIDI1ToUMP()'s reassignment of a real-time System
+      // message (CIN 15, data byte's high bit set) to CIN 5 (SYSEX_END_1BYTE)
+      // so the word-count estimate here matches what conversion will do.
+      uint8_t code_index = peekBuf[0] & 0x0f;
+      if (code_index == MIDI_1_CIN_1BYTE_DATA && (peekBuf[1] & 0x80))
+      {
+        code_index = MIDI_1_CIN_SYSEX_END_1BYTE;
+      }
+      bool needsTwoWords = (code_index == MIDI_1_CIN_SYSEX_START)
+                         || (code_index == MIDI_1_CIN_SYSEX_END_1BYTE)
+                         || (code_index == MIDI_1_CIN_SYSEX_END_2BYTE)
+                         || (code_index == MIDI_1_CIN_SYSEX_END_3BYTE);
+      if (needsTwoWords && (numAvail - numRead) < 2)
+      {
+        break;
+      }
+
       // Get next word from USB
       uint32_t readWord;
       if (tu_fifo_read_n(&ump->rx_ff, (void *)&readWord, sizeof(uint32_t)) != sizeof(uint32_t) )
       {
         goto END_READ;
       }
-      numProcessed++;
       //readWord = RtlUlongByteSwap(readWord);
 
       if (readWord)


### PR DESCRIPTION
## Summary
- Follow-up to #18. `tud_ump_read_impl()`'s alt-0 (MIDI 1) loop required 2 free output slots before converting another raw word, since a SysEx7 conversion can produce up to 2 UMP words.
- Channel Voice and System Common words only ever produce 1 UMP word, so the loop could stop 1 slot early and defer a perfectly fittable word to the next call, leaving the caller's buffer under-filled (not data loss -- the raw word stays queued in the FIFO for the next call).
- Peek the next raw word's CIN before deciding how much space to require: only insist on 2 free slots when the CIN is SysEx-producing (`SYSEX_START`, `SYSEX_END_1BYTE/2BYTE/3BYTE`), mirroring `tud_USBMIDI1ToUMP()`'s CIN-15-with-high-bit-set reassignment to `SYSEX_END_1BYTE` so the estimate matches what conversion actually does.

Fixes #18

Based on `main` (independent of the not-yet-merged #17, which this branch does not depend on).

## Test plan
- [ ] Confirm on real hardware that a read with a small buffer size now returns a full buffer of 1-word (Channel Voice/System) messages instead of stopping 1 word short.