### PR TITLE
Add host-side unit tests for the legacy MIDI1 read path

### DIFF
--- a/test/host/.gitignore
+++ b/test/host/.gitignore
@@ -1,0 +1,1 @@
+test_ump_device

--- a/test/host/Makefile
+++ b/test/host/Makefile
@@ -1,0 +1,41 @@
+# Host-side unit test build for ump_device.cpp's read path. No cross
+# toolchain or hardware needed -- links the real ump_device.cpp against the
+# real (vendored) TinyUSB tusb_fifo.c, with the small stubs.c standing in
+# for the rest of the USB device stack.
+#
+# TUSB_ROOT can be overridden to point at any TinyUSB checkout/vendor copy
+# whose src/ layout matches upstream, e.g.:
+#   make TUSB_ROOT=/path/to/pico-sdk/lib/tinyusb
+TUSB_ROOT ?= $(HOME)/.pico-sdk/sdk/2.3.0/lib/tinyusb
+TUSB_SRC  := $(TUSB_ROOT)/src
+
+CC  := cc
+CXX := c++
+
+CPPFLAGS := -I. -I../.. -I$(TUSB_SRC) -DUMP_DEVICE_UNIT_TEST
+CFLAGS   := -std=c11   -Wall -Wextra -g
+CXXFLAGS := -std=c++17 -Wall -Wextra -g
+
+OBJS := test_ump_device.o stubs.o tusb_fifo.o ump_device.o
+
+test_ump_device: $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+test_ump_device.o: test_ump_device.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+
+stubs.o: stubs.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+
+tusb_fifo.o: $(TUSB_SRC)/common/tusb_fifo.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+
+ump_device.o: ../../ump_device.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
+
+.PHONY: check clean
+check: test_ump_device
+	./test_ump_device
+
+clean:
+	rm -f $(OBJS) test_ump_device

--- a/test/host/README.md
+++ b/test/host/README.md
@@ -1,0 +1,38 @@
+# Host-side unit tests
+
+Regression tests for `tud_ump_read_impl()`'s alt-0 (legacy USB-MIDI1 byte
+stream) read path, covering issues [#15](https://github.com/midi2-dev/tusb_ump/issues/15)
+and [#18](https://github.com/midi2-dev/tusb_ump/issues/18):
+
+1. **No buffer overflow** -- a dense stream of SysEx7 messages never yields
+   more UMP words than requested, regardless of how many raw USB-MIDI1
+   words each one takes to complete.
+2. **No unnecessary stalling** -- a stream of 1-word messages (Channel
+   Voice, System Common) fully drains a request rather than stopping 1
+   word short "just in case" the next message needs 2.
+3. **Split-call continuity** -- draining the same input across several
+   small reads gives the same words, in the same order, as one large read.
+
+No hardware required. Links the real `../../ump_device.cpp` and TinyUSB's
+real (unmodified) `common/tusb_fifo.c` against a handful of stubs
+(`stubs.c`) standing in for the rest of the USB device stack, plus two
+test-only hooks in `ump_device.cpp`/`.h` guarded by `UMP_DEVICE_UNIT_TEST`
+(`tud_ump_test_set_ep_out`, `tud_ump_test_rx_write`) that let a test mark an
+interface "open" and inject raw bytes without a real USB enumeration.
+
+## Running
+
+```sh
+make check
+```
+
+By default this builds against the TinyUSB copy vendored by the Pico SDK
+(`~/.pico-sdk/sdk/<version>/lib/tinyusb`). Point at a different TinyUSB
+checkout with:
+
+```sh
+make check TUSB_ROOT=/path/to/tinyusb
+```
+
+Any TinyUSB checkout works — only its portable `common/tusb_fifo.c` is
+compiled, nothing MCU-specific.

--- a/test/host/stubs.c
+++ b/test/host/stubs.c
@@ -1,0 +1,76 @@
+// Minimal stand-ins for the TinyUSB device-stack entry points ump_device.cpp
+// references (control transfer / endpoint management / xfer/itf-selection
+// callbacks), so this test can link without a real USB device stack or
+// hardware. None of these are exercised by the read-path tests here --
+// they only satisfy the linker for umpd_open/umpd_control_xfer_cb/
+// umpd_xfer_cb and _prep_out_transaction(), none of which the tests call
+// except the latter (invoked at the end of every tud_ump_read_impl()).
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "device/usbd.h"
+#include "ump_device.h"
+
+bool usbd_edpt_claim(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) rhport;
+  (void) ep_addr;
+  return true;
+}
+
+bool usbd_edpt_release(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) rhport;
+  (void) ep_addr;
+  return true;
+}
+
+bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
+{
+  (void) rhport;
+  (void) ep_addr;
+  (void) buffer;
+  (void) total_bytes;
+  return true;
+}
+
+bool usbd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * desc_ep)
+{
+  (void) rhport;
+  (void) desc_ep;
+  return true;
+}
+
+bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const * request, void* buffer, uint16_t len)
+{
+  (void) rhport;
+  (void) request;
+  (void) buffer;
+  (void) len;
+  return true;
+}
+
+bool tud_control_status(uint8_t rhport, tusb_control_request_t const * request)
+{
+  (void) rhport;
+  (void) request;
+  return true;
+}
+
+void tud_ump_rx_cb(uint8_t itf)
+{
+  (void) itf;
+}
+
+void tud_ump_set_itf_cb(uint8_t itf, uint8_t alt)
+{
+  (void) itf;
+  (void) alt;
+}
+
+bool tud_ump_get_req_itf_cb(uint8_t rhport, tusb_control_request_t const * p_request)
+{
+  (void) rhport;
+  (void) p_request;
+  return false;
+}

--- a/test/host/test_ump_device.c
+++ b/test/host/test_ump_device.c
@@ -1,0 +1,148 @@
+// Host-side regression tests for tud_ump_read_impl()'s alt-0 (legacy
+// USB-MIDI1 byte stream) read path in ump_device.cpp, covering:
+//   1. No buffer overflow (issue #15 / PR #17)
+//   2. No unnecessary 1-word stalling (issue #18 / PR #19)
+//   3. Byte continuity across multiple reads mid-SysEx
+//
+// No test framework -- plain assert(), built as a small host executable
+// (see Makefile). Uses UMP_DEVICE_UNIT_TEST-guarded hooks in ump_device.cpp
+// to inject raw USB-MIDI1 bytes without a real USB enumeration.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "tusb.h"
+#include "ump_device.h"
+
+#define ITF 0
+
+// USB-MIDI1 CIN nibbles (see ump_device.cpp's MIDI_1_CIN_* enum via ump.h).
+#define CIN_SYSEX_START   0x4
+#define CIN_SYSEX_END_3B  0x7
+#define CIN_NOTE_ON       0x9
+
+static void push_word(uint8_t cin, uint8_t cable, uint8_t b1, uint8_t b2, uint8_t b3)
+{
+    uint8_t pkt[4] = { (uint8_t)((cable << 4) | cin), b1, b2, b3 };
+    uint16_t written = tud_ump_test_rx_write(ITF, pkt, sizeof(pkt));
+    assert(written == sizeof(pkt));
+}
+
+static void reset_interface(void)
+{
+    umpd_init();
+    tud_ump_test_set_ep_out(ITF, 0x01); // any nonzero value marks the itf "open"
+}
+
+// A raw USB-MIDI1 word carrying a SysEx7 CIN (start/end variants) converts
+// to 2 UMP words (a 64-bit SYSEX7 packet); mirrors ump_device.cpp's own
+// MIDI_1_CIN_SYSEX_* handling. Encodes "F0 7E 7F 06 01 F7" (a 6-byte
+// Universal Device Inquiry, matching issue #15's original repro) as two
+// USB-MIDI1 packets: CIN 4 (start, carrying F0 + 2 data bytes) then CIN 7
+// (end-3-byte, carrying 2 data bytes + the F7 terminator).
+static void push_sysex_message(void)
+{
+    push_word(CIN_SYSEX_START, 0, 0xF0, 0x7E, 0x7F);
+    push_word(CIN_SYSEX_END_3B, 0, 0x06, 0x01, 0xF7);
+}
+
+static void test_no_overflow_on_dense_sysex(void)
+{
+    reset_interface();
+
+    // Queue several complete SysEx7 messages back-to-back. Each message is
+    // 2 raw USB-MIDI1 packets (start + end), and each of those individually
+    // converts to a 2-word 64-bit UMP packet -- so with numAvail=4 a buggy
+    // loop bounding on raw words consumed (instead of UMP words written)
+    // could write up to ~2x that in a single call.
+    const int num_messages = 8;
+    for (int i = 0; i < num_messages; i++)
+    {
+        push_sysex_message();
+    }
+
+    uint32_t canary = 0xDEADBEEFu;
+    struct { uint32_t words[4]; uint32_t canary; } guarded;
+    guarded.canary = canary;
+
+    uint16_t total = 0;
+    for (int call = 0; call < 20; call++)
+    {
+        uint16_t n = tud_ump_read_ntoh(ITF, guarded.words, 4);
+        assert(n <= 4); // never more than requested
+        assert(guarded.canary == canary); // never written past the buffer
+        total += n;
+        if (n == 0) break;
+    }
+    // Each message = 2 raw packets (start + end), each producing a 2-word
+    // UMP packet: 4 UMP words recovered per message.
+    assert(total == num_messages * 4);
+
+    printf("PASS: test_no_overflow_on_dense_sysex (%u words recovered)\n", total);
+}
+
+static void test_no_unnecessary_stall_on_cv_messages(void)
+{
+    reset_interface();
+
+    // 4 Channel Voice (Note On) messages queued; each converts to exactly
+    // 1 UMP word. A read for numAvail=3 should return all 3 fittable words
+    // in one call, not stop 1 short reserving room for a SysEx that isn't
+    // coming.
+    for (int i = 0; i < 4; i++)
+    {
+        push_word(CIN_NOTE_ON, 0, 0x90, (uint8_t)(60 + i), 100);
+    }
+
+    uint32_t buf[3];
+    uint16_t n = tud_ump_read_ntoh(ITF, buf, 3);
+    assert(n == 3);
+
+    printf("PASS: test_no_unnecessary_stall_on_cv_messages (n=%u)\n", n);
+}
+
+static void test_split_call_continuity(void)
+{
+    reset_interface();
+
+    for (int i = 0; i < 6; i++)
+    {
+        push_word(CIN_NOTE_ON, 0, 0x90, (uint8_t)(20 + i), 100);
+    }
+
+    // Drain via several small reads instead of one large one, and compare
+    // against draining the same input in one big read.
+    uint32_t small_run[6] = {0};
+    uint16_t total = 0;
+    while (total < 6)
+    {
+        uint32_t chunk[2];
+        uint16_t n = tud_ump_read_ntoh(ITF, chunk, 2);
+        assert(n > 0);
+        memcpy(&small_run[total], chunk, n * sizeof(uint32_t));
+        total += n;
+    }
+
+    reset_interface();
+    for (int i = 0; i < 6; i++)
+    {
+        push_word(CIN_NOTE_ON, 0, 0x90, (uint8_t)(20 + i), 100);
+    }
+    uint32_t big_run[6];
+    uint16_t n = tud_ump_read_ntoh(ITF, big_run, 6);
+    assert(n == 6);
+
+    assert(memcmp(small_run, big_run, sizeof(big_run)) == 0);
+
+    printf("PASS: test_split_call_continuity\n");
+}
+
+int main(void)
+{
+    test_no_overflow_on_dense_sysex();
+    test_no_unnecessary_stall_on_cv_messages();
+    test_split_call_continuity();
+    printf("All tests passed.\n");
+    return 0;
+}

--- a/test/host/tusb_config.h
+++ b/test/host/tusb_config.h
@@ -1,0 +1,42 @@
+// Minimal TinyUSB config for host-side unit testing of ump_device.cpp.
+// Not a real MCU target -- only tusb_fifo.c and ump_device.cpp are
+// compiled/linked, with the rest of the USB device stack stubbed out in
+// stubs.c, so most of this only needs to satisfy header requirements.
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CFG_TUSB_MCU              OPT_MCU_NONE
+#define CFG_TUSB_OS               OPT_OS_NONE
+#define BOARD_DEVICE_RHPORT_NUM   0
+#define CFG_TUSB_RHPORT0_MODE     (OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED)
+
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN
+#endif
+
+#define CFG_TUD_ENDPOINT0_SIZE    64
+
+#define CFG_TUD_CDC               0
+#define CFG_TUD_MSC               0
+#define CFG_TUD_HID               0
+#define CFG_TUD_MIDI              0
+#define CFG_TUD_VENDOR            0
+#define CFG_TUD_UMP               1
+
+// Small on purpose: buffer-boundary behavior is exactly what these tests
+// exercise, and a small FIFO makes it easy to feed precisely-sized bursts.
+#define CFG_TUD_UMP_RX_BUFSIZE    64
+#define CFG_TUD_UMP_TX_BUFSIZE    64
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -1463,5 +1463,17 @@ COMPLETE_1BYTE:
     return true;
 }
 
+#ifdef UMP_DEVICE_UNIT_TEST
+void tud_ump_test_set_ep_out(uint8_t itf, uint8_t ep_out)
+{
+    _umpd_itf[itf].ep_out = ep_out;
+}
+
+uint16_t tud_ump_test_rx_write(uint8_t itf, const uint8_t* data, uint16_t n)
+{
+    return tu_fifo_write_n(&_umpd_itf[itf].rx_ff, data, n);
+}
+#endif
+
 } // extern "C"
 #endif

--- a/ump_device.h
+++ b/ump_device.h
@@ -115,6 +115,18 @@ void     umpd_reset           (uint8_t rhport);
 uint16_t umpd_open            (uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len);
 bool     umpd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
 bool     umpd_xfer_cb         (uint8_t rhport, uint8_t edpt_addr, xfer_result_t result, uint32_t xferred_bytes);
+
+#ifdef UMP_DEVICE_UNIT_TEST
+//--------------------------------------------------------------------+
+// Test-only hooks (test/host/) -- not part of the public driver API.
+// Let host-side unit tests drive an interface without a real USB
+// enumeration: mark it "open" (ep_out set) and inject raw bytes as if
+// received from the USB OUT endpoint.
+//--------------------------------------------------------------------+
+void     tud_ump_test_set_ep_out (uint8_t itf, uint8_t ep_out);
+uint16_t tud_ump_test_rx_write   (uint8_t itf, const uint8_t* data, uint16_t n);
+#endif
+
 #ifdef __cplusplus
  }
 #endif


### PR DESCRIPTION
## Summary
- Stacked on #19 (which is stacked on #17) -- targets that branch as its base since these tests exercise the fixed behavior from both.
- Adds `test/host/`, a hardware-free regression suite for `tud_ump_read_impl()`'s alt-0 (legacy USB-MIDI1 byte stream) read path:
  1. **No buffer overflow** (issue #15 / #17): a dense SysEx7 stream never yields more UMP words than requested.
  2. **No unnecessary stalling** (issue #18 / #19): a stream of 1-word Channel Voice messages fully drains a request instead of stopping 1 word short.
  3. **Split-call continuity**: draining the same input across several small reads matches one large read.
- Links the real `ump_device.cpp` against TinyUSB's real, unmodified `common/tusb_fifo.c`, with a handful of stubs (`test/host/stubs.c`) standing in for the rest of the USB device stack -- no cross toolchain or hardware needed, just `make check`.
- Adds two small test-only hooks to `ump_device.cpp`/`.h`, guarded by `UMP_DEVICE_UNIT_TEST` so they compile out of normal (non-test) builds: `tud_ump_test_set_ep_out()` and `tud_ump_test_rx_write()`, letting a test mark an interface "open" and inject raw bytes without a real USB enumeration.

I verified these tests actually catch both regressions before finalizing them: reverting the read loop to its pre-#17 form fails the overflow test, and reverting just the peek-CIN logic (#19) while keeping the #17 fix fails the stalling test.

## Test plan
- [x] `cd test/host && make check` -- all 3 tests pass against the fixed code.
- [x] Confirmed test 1 fails against the pre-#17 code (manually reverted locally, not committed).
- [x] Confirmed test 2 fails with #17 alone but not #19 (manually reverted locally, not committed).