### PR TITLE
Update AmeNote/MIDI2.dev copyright years to 2023-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The tusb_ump for tinyUSB driver was developed in compliance to the standards pro
 
 ## MIT License
 
-Copyright (c) 2023 MIDI2.dev
+Copyright (c) 2023-2026 MIDI2.dev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -82,4 +82,4 @@ We invite for collaborative and constructive contributions. You can contribute b
 TODO: Contribution agreement.
 
 ##### AmeNote, AmeNote Logo and ProtoZOA are trademarks of AmeNote Inc.
-##### Copyright (c) MIDI2.dev, 2023.
+##### Copyright (c) MIDI2.dev, 2023-2026.

--- a/examples/tusb_ump_lb/src/main.c
+++ b/examples/tusb_ump_lb/src/main.c
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Michael Loh (AmeNote.com)
+ * Copyright (c) 2023-2026 Michael Loh (AmeNote.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/examples/tusb_ump_lb/src/usb_descriptors.c
+++ b/examples/tusb_ump_lb/src/usb_descriptors.c
@@ -2,7 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
- * Copyright (c) 2022 Michael Loh (AmeNote.com)
+ * Copyright (c) 2023-2026 Michael Loh (AmeNote.com)
  * Copyright (c) 2022 Franz Detro (native-instruments.de)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/ump.h
+++ b/ump.h
@@ -2,7 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
- * Copyright (c) 2022 Michael Loh (AmeNote.com)
+ * Copyright (c) 2023-2026 Michael Loh (AmeNote.com)
  * Copyright (c) 2022 Franz Detro (native-instruments.de)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -2,7 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
- * Copyright (c) 2022 Michael Loh (AmeNote.com)
+ * Copyright (c) 2023-2026 Michael Loh (AmeNote.com)
  *
  * NOTE: Code adjustments made to support USB MIDI 2.0 UMP Packet format as
  * Alternate Interface 1. See USB Device Class Definition for MIDI Devices,
@@ -1200,7 +1200,7 @@ Routine Description:
 
 Copyright 2023 Association of Musical Electronics Industry
 Copyright 2023 Microsoft
-Driver source code developed by AmeNote. Some components Copyright 2023 AmeNote Inc.
+Driver source code developed by AmeNote. Some components Copyright 2023-2026 AmeNote Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ump_device.h
+++ b/ump_device.h
@@ -2,7 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
- * Copyright (c) 2022 Michael Loh (AmeNote.com)
+ * Copyright (c) 2023-2026 Michael Loh (AmeNote.com)
  * Copyright (c) 2022 Franz Detro (native-instruments.de)
  *
  * NOTE: Code adjustments made to support USB MIDI 2.0 UMP Packet format as


### PR DESCRIPTION
Reflects ongoing work on this driver from 2023 through 2026. Only updates the copyright lines attributed to Michael Loh/AmeNote.com and MIDI2.dev; third-party attributions (tinyusb.org, native-instruments.de, AMEI, Microsoft, Saulo Verissimo) are left as their original authors dated them.