### PR TITLE
Fix single-byte System Common/real-time messages emitting a spurious 2nd word

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ flowchart TD
     F --> H["MT=3 Data64, wordCount=2"]
     G --> H
     D -->|"0x5: SysEx end-1-byte or<br/>single-byte System Common"| I{"byte1 high bit set<br/>and != F7?"}
-    I -->|yes| J["MT=1 System, wordCount=2<br/>(2nd word unused)"]
+    I -->|yes| J["MT=1 System, wordCount=1"]
     I -->|"no, in SysEx, byte1==F7"| K["status=END, clear in-SysEx<br/>MT=3, wordCount=2"]
     I -->|"no, not in SysEx"| L[reject: malformed]
     D -->|"0x6: SysEx end-2-byte"| M["status=END or COMPLETE<br/>MT=3, wordCount=2"]

--- a/test/host/test_ump_device.c
+++ b/test/host/test_ump_device.c
@@ -7,6 +7,8 @@
 //      2-word SysEx completion must not short-change a request when the
 //      next message is actually a 1-word Channel Voice/System Common.
 //   3. Byte continuity across multiple reads mid-SysEx
+//   4. A single-byte System Common/real-time message (e.g. Timing Clock)
+//      converts to exactly 1 UMP word, not 2 with a spurious zero word.
 //
 // No test framework -- plain assert(), built as a small host executable
 // (see Makefile). Uses UMP_DEVICE_UNIT_TEST-guarded hooks in ump_device.cpp
@@ -25,6 +27,9 @@
 #define CIN_SYSEX_START   0x4
 #define CIN_SYSEX_END_3B  0x7
 #define CIN_NOTE_ON       0x9
+#define CIN_1BYTE_DATA    0xF
+
+#define MIDI1_TIMING_CLOCK 0xF8
 
 static void push_word(uint8_t cin, uint8_t cable, uint8_t b1, uint8_t b2, uint8_t b3)
 {
@@ -142,11 +147,38 @@ static void test_split_call_continuity(void)
     printf("PASS: test_split_call_continuity\n");
 }
 
+static void test_system_realtime_single_word(void)
+{
+    reset_interface();
+
+    // A single-byte System Common/real-time status (CIN 0xF, data byte's
+    // high bit set) is reassigned internally to CIN 0x5, which is shared
+    // with the genuine 2-word SysEx-end-1-byte completion -- it must still
+    // convert to exactly 1 UMP word (MT=1 System), not 2 with a spurious
+    // trailing zero word.
+    push_word(CIN_1BYTE_DATA, 0, MIDI1_TIMING_CLOCK, 0x00, 0x00);
+    push_word(CIN_NOTE_ON, 0, 0x90, 60, 100);
+
+    uint32_t buf[2];
+    uint16_t n = tud_ump_read_ntoh(ITF, buf, 2);
+    assert(n == 2); // 1 word each, not 2 (clock + spurious zero) leaving the
+                     // Note On stranded in the FIFO for another call
+
+    uint32_t expected_clock_word = ((uint32_t)UMP_MT_SYSTEM << 24) | ((uint32_t)MIDI1_TIMING_CLOCK << 16);
+    uint32_t expected_note_on_word = ((uint32_t)UMP_MT_MIDI1_CV << 24) | (0x90u << 16) | (60u << 8) | 100u;
+    assert(buf[0] == expected_clock_word);
+    assert(buf[1] == expected_note_on_word); // fails if a spurious 2nd word
+                                              // pushed the real Note On out
+
+    printf("PASS: test_system_realtime_single_word (n=%u)\n", n);
+}
+
 int main(void)
 {
     test_no_overflow_on_dense_sysex();
     test_no_unnecessary_stall_on_cv_messages();
     test_split_call_continuity();
+    test_system_realtime_single_word();
     printf("All tests passed.\n");
     return 0;
 }

--- a/ump_device.cpp
+++ b/ump_device.cpp
@@ -360,13 +360,18 @@ static uint16_t tud_ump_read_impl( uint8_t itf, uint32_t *pkts, uint16_t numAvai
       // Mirror tud_USBMIDI1ToUMP()'s reassignment of a real-time System
       // message (CIN 15, data byte's high bit set) to CIN 5 (SYSEX_END_1BYTE)
       // so the word-count estimate here matches what conversion will do.
+      // That reassigned case converts to a single 1-word UMP System message,
+      // not the 2-word SysEx7 completion a literal CIN 5 produces, so it's
+      // excluded from needsTwoWords below.
       uint8_t code_index = peekBuf[0] & 0x0f;
+      bool isReassignedRealtime = false;
       if (code_index == MIDI_1_CIN_1BYTE_DATA && (peekBuf[1] & 0x80))
       {
         code_index = MIDI_1_CIN_SYSEX_END_1BYTE;
+        isReassignedRealtime = true;
       }
       bool needsTwoWords = (code_index == MIDI_1_CIN_SYSEX_START)
-                         || (code_index == MIDI_1_CIN_SYSEX_END_1BYTE)
+                         || (code_index == MIDI_1_CIN_SYSEX_END_1BYTE && !isReassignedRealtime)
                          || (code_index == MIDI_1_CIN_SYSEX_END_2BYTE)
                          || (code_index == MIDI_1_CIN_SYSEX_END_3BYTE);
       if (needsTwoWords && (numAvail - numRead) < 2)
@@ -1274,11 +1279,15 @@ tud_USBMIDI1ToUMP(
         if ( (pBuffer[1] & 0x80) // most significant bit set and not sysex ending
             && (pBuffer[1] != MIDI_1_STATUS_SYSEX_END))
         {
+            // A single-byte System message is one 32-bit UMP word (MT=1),
+            // not a 64-bit SysEx7 packet -- fill and pad it directly rather
+            // than falling into the 2-word SysEx completion path below.
             umpPkt->umpData.umpBytes[0] = UMP_MT_SYSTEM | cbl_num;
             umpPkt->umpData.umpBytes[1] = pBuffer[1];
-            firstByte = 1;
-            lastByte = 1;
-            goto COMPLETE_1BYTE;
+            umpPkt->umpData.umpBytes[2] = 0x00;
+            umpPkt->umpData.umpBytes[3] = 0x00;
+            umpPkt->wordCount = 1;
+            break;
         }
 
         umpPkt->umpData.umpBytes[0] = UMP_MT_DATA_64 | cbl_num;
@@ -1298,7 +1307,6 @@ tud_USBMIDI1ToUMP(
             return false;
         }
 
-COMPLETE_1BYTE:
         umpPkt->wordCount = 2;
         // Transfer in bytes
         copyPos = firstByte;


### PR DESCRIPTION
## Summary
- `tud_USBMIDI1ToUMP()`'s `MIDI_1_CIN_SYSEX_END_1BYTE` case shared a `wordCount = 2` code path (the `COMPLETE_1BYTE` label) between two very different things: the genuine SysEx-end-1-byte completion (a 64-bit UMP data message, correctly 2 words) and single-byte System Common/real-time messages reassigned from CIN 0xF (Timing Clock, Start, Continue, Stop, Active Sensing, Reset, Tune Request, and the undefined F4/F5/F9/FD statuses).
- A UMP System message (MT=1) is a single 32-bit word, so every one of these real-time/System Common messages produced a spurious trailing all-zero UMP word on the legacy alt-0 read path.
- Gives the System Common/real-time branch its own `wordCount = 1` and fills/pads its single word directly, instead of falling into the shared 2-word label (which now only serves the genuine SysEx-end-1-byte case, so the `goto`/label indirection is removed too).
- Updates `tud_ump_read_impl()`'s peek-ahead word-count estimate (added in the earlier buffer-fix work) so it no longer reserves 2 output slots for this reassigned case, keeping the estimate consistent with the fix.
- Adds a host-side regression test (`test_system_realtime_single_word`) that queues a Timing Clock message followed by a Note On and asserts both convert to exactly 1 word each with the correct content -- verified this test fails against the pre-fix code (the spurious 2nd word pushes the Note On out of the request) and passes with the fix.

Fixes #23

## Test plan
- [x] `cd test/host && make check` -- all 4 tests pass, clean build.
- [x] Confirmed the new test fails against the pre-fix code (manually reverted locally, not committed).
- [x] `cd examples/tusb_ump_lb && cmake -S . -B build -G Ninja && cmake --build build` -- clean full RP2040 build.