### PR TITLE
Add tusb_ump_host_demo: USB Host UMP reference/bring-up example

### DIFF
--- a/examples/tusb_ump_host_demo/CMakeLists.txt
+++ b/examples/tusb_ump_host_demo/CMakeLists.txt
@@ -1,0 +1,85 @@
+# tusb_ump_host_demo - USB Host UMP bring-up / demo app
+#
+# Default target is a Raspberry Pi Pico (RP2040) board. main.cpp has no
+# RP2040-specific code beyond board bring-up and the tinyusb_overrides/
+# hcd_rp2040.c swap below (an RP2040 host-controller-driver bugfix, see that
+# file's own header comment). Porting to another pico-sdk-supported board
+# with a native USB host controller is a matter of changing PICO_BOARD
+# below and dropping the hcd_rp2040.c override if that board's controller
+# doesn't need it. Porting to a non pico-sdk MCU means swapping this
+# CMakeLists.txt / pico_sdk_import.cmake for that target's TinyUSB host
+# integration and keeping ../../ump_host.cpp, ../../ump_host.h and
+# ../../ump.h as-is - they are a generic TinyUSB class driver.
+
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.3.0)
+set(toolchainVersion 15_2_Rel1)
+set(picotoolVersion 2.3.0)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
+
+set(PICO_BOARD pico CACHE STRING "Board type")
+
+cmake_minimum_required(VERSION 3.13)
+
+include(pico_sdk_import.cmake)
+
+project(tusb_ump_host_demo C CXX ASM)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+if (PICO_SDK_VERSION_STRING VERSION_LESS "2.0.0")
+    message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.0.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+endif()
+
+pico_sdk_init()
+
+add_executable(tusb_ump_host_demo
+        src/main.cpp
+        ../../ump_host.cpp
+        )
+
+target_include_directories(tusb_ump_host_demo PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/src
+        ../..
+        )
+
+target_link_libraries(tusb_ump_host_demo
+        pico_stdlib
+        pico_stdio
+        tinyusb_host
+        )
+
+# Swap in the patched hcd_rp2040.c (see tinyusb_overrides/hcd_rp2040.c's own
+# header comment: reports a genuine hardware RX_TIMEOUT condition as
+# XFER_RESULT_TIMEOUT instead of silently hanging the shared control
+# endpoint forever) in place of pico-sdk's stock copy, which
+# tinyusb_host_base injects into every linking target via
+# target_sources(... INTERFACE ...). Scoped to this app's target only - the
+# shared pico-sdk install is never modified.
+get_target_property(_tinyusb_host_base_srcs tinyusb_host_base INTERFACE_SOURCES)
+list(FILTER _tinyusb_host_base_srcs EXCLUDE REGEX "portable/raspberrypi/rp2040/hcd_rp2040\\.c$")
+set_target_properties(tinyusb_host_base PROPERTIES INTERFACE_SOURCES "${_tinyusb_host_base_srcs}")
+target_sources(tusb_ump_host_demo PRIVATE tinyusb_overrides/hcd_rp2040.c)
+# rp2040_usb.h is a private header that lives alongside the stock
+# hcd_rp2040.c in the SDK (not on any public include path); our override
+# needs it too.
+target_include_directories(tusb_ump_host_demo PRIVATE
+        ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/rp2040
+        )
+
+# Logs (device enumeration, GTB dumps, received UMP words) go out the
+# board's default UART, not USB - the only USB port is occupied by host
+# role itself.
+pico_enable_stdio_uart(tusb_ump_host_demo 1)
+pico_enable_stdio_usb(tusb_ump_host_demo 0)
+
+pico_add_extra_outputs(tusb_ump_host_demo)

--- a/examples/tusb_ump_host_demo/README.md
+++ b/examples/tusb_ump_host_demo/README.md
@@ -1,0 +1,101 @@
+# tusb_ump_host_demo - USB Host UMP Reference App
+
+A small reference app built on `tusb_ump`'s `ump_host` TinyUSB class driver.
+Plug a USB MIDI device (or a hub with one attached) into the board and it:
+
+- Prints basic identification for **any** attached USB device (VID/PID,
+  manufacturer/product/serial strings) as soon as it's mounted, MIDI or not
+  - useful during bring-up to confirm enumeration is happening at all.
+- Dumps the attached MIDI device's parsed (or synthesized, for
+  alt-setting-0-only devices) [Group Terminal Block](../../ump.h) info once
+  its UMP interface mounts.
+- Decodes and prints every incoming UMP word, on whichever MIDIStreaming
+  alternate setting the device presents:
+  - **Alt 0** - legacy USB-MIDI 1.0 byte stream (translated to UMP by the
+    driver)
+  - **Alt 1** - UMP / USB MIDI 2.0 native
+- Injects a test Note On/Off once a second (press SPACE to toggle) so you
+  can exercise the write path without needing a second app sending MIDI.
+
+It's meant as a small, self-contained reference for the API
+(`tuh_ump_read_ntoh` / `tuh_ump_write_hton`, mount/unmount callbacks) needed
+to build a real USB-MIDI-host application with this driver - not a product.
+
+## Hardware
+
+Default target is a Raspberry Pi Pico (RP2040). A Pico's USB port normally
+*senses* VBUS supplied by whatever it's plugged into; running it in **host**
+role flips that - the board must instead *supply* 5V onto its own VBUS pin
+so a downstream USB device can power up and enumerate. Wire the Pico's own
+5V rail (VSYS, or an external 5V supply) onto its USB connector's VBUS pin
+(directly, or via whatever power-switch/jumper your carrier board provides)
+before attaching a device - without it, nothing will enumerate.
+
+Since the Pico's only USB port is committed to host role, this example logs
+over the board's default UART (115200 8N1 - GP0/GP1 on a Pico) instead.
+
+## Logging
+
+```
+tusb_ump_host_demo -- USB Host UMP reference app
+Waiting for a USB MIDI device...
+Press SPACE to toggle the periodic test Note On/Off write (starts OFF).
+
+[USB] device mounted daddr=1 VID:PID=1234:5678 bcdUSB=0x0200 bcdDevice=0x0100 class=0/0/0
+  Manufacturer: Example Corp
+  Product: Example MIDI Keyboard
+  Serial Number: (no string descriptor)
+
+[UMP] mounted daddr=1 itf_num=1
+  alt_setting = 1 (native UMP)
+  USB MIDI Streaming class spec version (bcdMSC) = 0x0200
+  Group Terminal Blocks: 1
+    [0] ID=1 type=0x00 firstGroup=0 numGroups=1 protocol=0x02 maxInBW=0 maxOutBW=0
+[UMP daddr=1 itf=1] read word: 0x40903c64 (MT=0x4 group=0)
+[UMP]            0x00000000
+```
+
+## Runtime Controls
+
+Press **SPACE** at any time to toggle a periodic test Note On/Off (middle
+C, alternating every second) sent to every currently-mounted UMP device -
+useful for confirming the write path works even with nothing else sending
+MIDI to the device.
+
+## Building
+
+Requires the [Raspberry Pi Pico SDK](https://github.com/raspberrypi/pico-sdk)
+(2.0.0 or later) and its ARM toolchain, either installed via the [Pico VS
+Code extension](https://github.com/raspberrypi/pico-vscode) or with
+`PICO_SDK_PATH` set manually.
+
+```sh
+cmake -S . -B build -G Ninja
+cmake --build build
+```
+
+This produces `build/tusb_ump_host_demo.uf2`. Hold BOOTSEL while plugging in
+the Pico, then copy the UF2 onto the mass-storage drive that appears.
+
+## Trying it out
+
+Plug a USB MIDI 2.0 or USB-MIDI 1.0 device (or a hub with one attached) into
+the board's USB port. Watch the UART log for enumeration, then play a note
+on the device (or send MIDI to it from a DAW/controller) and watch it appear
+as decoded UMP words. Press SPACE to also see a test note make it back out
+to the device.
+
+### Porting to other targets
+
+Nothing in `src/main.cpp` is RP2040-specific except board bring-up
+(`stdio_init_all()`) and the `tinyusb_overrides/hcd_rp2040.c` swap in
+`CMakeLists.txt` (an RP2040 host-controller-driver bugfix - see that file's
+own header comment; drop it if your target's controller doesn't need it).
+The driver itself - [`../../ump_host.h`](../../ump_host.h) /
+[`../../ump_host.cpp`](../../ump_host.cpp) - is a generic TinyUSB host class
+driver with no RP2040 dependencies. To port to another pico-sdk board with a
+native USB host controller, change `PICO_BOARD` in `CMakeLists.txt` (or pass
+`-DPICO_BOARD=...` on the command line). To port to a non pico-sdk MCU, swap
+this project's `CMakeLists.txt`/`pico_sdk_import.cmake` for that target's
+TinyUSB host build integration and carry `ump_host.h`/`ump_host.cpp`/`ump.h`
+over unchanged.

--- a/examples/tusb_ump_host_demo/pico_sdk_import.cmake
+++ b/examples/tusb_ump_host_demo/pico_sdk_import.cmake
@@ -1,0 +1,121 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+# Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+# disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_TAG} AND (NOT PICO_SDK_FETCH_FROM_GIT_TAG))
+    set(PICO_SDK_FETCH_FROM_GIT_TAG $ENV{PICO_SDK_FETCH_FROM_GIT_TAG})
+    message("Using PICO_SDK_FETCH_FROM_GIT_TAG from environment ('${PICO_SDK_FETCH_FROM_GIT_TAG}')")
+endif ()
+
+if (PICO_SDK_FETCH_FROM_GIT AND NOT PICO_SDK_FETCH_FROM_GIT_TAG)
+  set(PICO_SDK_FETCH_FROM_GIT_TAG "master")
+  message("Using master as default value for PICO_SDK_FETCH_FROM_GIT_TAG")
+endif()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+set(PICO_SDK_FETCH_FROM_GIT_TAG "${PICO_SDK_FETCH_FROM_GIT_TAG}" CACHE FILEPATH "release tag for SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+        )
+
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            # GIT_SUBMODULES_RECURSE was added in 3.17
+            if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+                        GIT_SUBMODULES_RECURSE FALSE
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            else ()
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            endif ()
+
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/examples/tusb_ump_host_demo/src/main.cpp
+++ b/examples/tusb_ump_host_demo/src/main.cpp
@@ -1,0 +1,362 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Michael Loh (AmeNote.com)
+ *
+ * tusb_ump_host_demo -- a small reference app for `ump_host`, the USB Host
+ * UMP TinyUSB class driver: enumerates whatever USB MIDI device is plugged
+ * in (native UMP or legacy USB-MIDI 1.0), dumps its parsed (or synthesized,
+ * for alt-setting-0-only devices) Group Terminal Block info over UART,
+ * reports basic device identification for any attached USB device (not
+ * just MIDI ones), decodes and prints every incoming UMP word via the real
+ * read API (both alt settings), and injects a test Note On/Off once a
+ * second to exercise the write path (toggle with SPACE -- see README.md's
+ * Runtime Controls).
+ *
+ * Not a product -- meant as a self-contained reference for the API
+ * (`tuh_ump_read_ntoh` / `tuh_ump_write_hton`, mount/unmount callbacks)
+ * needed to build a real USB-MIDI-host application with this driver.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <cstdio>
+
+#include "pico/stdlib.h"
+#include "tusb.h"
+#include "host/hcd.h"
+#include "ump_host.h"
+
+#define LANGUAGE_ID 0x0409 // English (US)
+
+//--------------------------------------------------------------------+
+// UTF-16LE -> UTF-8 string descriptor helper (same approach as TinyUSB's
+// own host/device_info example)
+//--------------------------------------------------------------------+
+
+static void print_utf16(uint16_t* temp_buf, size_t buf_len)
+{
+  if ((temp_buf[0] & 0xff) == 0) { printf("(none)"); return; }
+
+  size_t utf16_len = ((temp_buf[0] & 0xff) - 2) / sizeof(uint16_t);
+  uint8_t* utf8 = (uint8_t*) temp_buf;
+  size_t out_pos = 0;
+
+  for (size_t i = 0; i < utf16_len && out_pos + 3 < buf_len * sizeof(uint16_t); i++)
+  {
+    uint16_t chr = temp_buf[1 + i];
+    if (chr < 0x80)
+    {
+      utf8[out_pos++] = (uint8_t) chr;
+    }
+    else if (chr < 0x800)
+    {
+      utf8[out_pos++] = (uint8_t) (0xC0 | (chr >> 6 & 0x1F));
+      utf8[out_pos++] = (uint8_t) (0x80 | (chr >> 0 & 0x3F));
+    }
+    else
+    {
+      utf8[out_pos++] = (uint8_t) (0xE0 | (chr >> 12 & 0x0F));
+      utf8[out_pos++] = (uint8_t) (0x80 | (chr >> 6 & 0x3F));
+      utf8[out_pos++] = (uint8_t) (0x80 | (chr >> 0 & 0x3F));
+    }
+  }
+  utf8[out_pos] = '\0';
+
+  printf("%s", (char*) utf8);
+}
+
+static void print_string_desc(uint8_t daddr, uint8_t index, char const* label)
+{
+  if (index == 0)
+  {
+    printf("  %s: (no string descriptor)\r\n", label);
+    return;
+  }
+
+  uint16_t buf[64];
+  printf("  %s: ", label);
+  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_string_sync(daddr, index, LANGUAGE_ID, buf, sizeof(buf)))
+  {
+    print_utf16(buf, sizeof(buf) / 2);
+  }
+  else
+  {
+    printf("(failed to read)");
+  }
+  printf("\r\n");
+}
+
+//--------------------------------------------------------------------+
+// UMP class driver diagnostics
+//--------------------------------------------------------------------+
+
+static void print_gtb_info(uint8_t daddr, uint8_t itf_num)
+{
+  midi2_desc_group_terminal_block_t const* gtb = NULL;
+  uint8_t const count = tuh_ump_get_group_terminal_blocks(daddr, itf_num, &gtb);
+  uint8_t const alt = tuh_ump_alt_setting(daddr, itf_num);
+
+  printf("  alt_setting = %u (%s)\r\n", alt, alt == 1 ? "native UMP" : "legacy MIDI 1.0");
+  printf("  USB MIDI Streaming class spec version (bcdMSC) = 0x%04x\r\n", tuh_ump_get_bcd_msc(daddr, itf_num));
+  printf("  Group Terminal Blocks: %u\r\n", count);
+
+  for (uint8_t i = 0; i < count; i++)
+  {
+    midi2_desc_group_terminal_block_t const* blk = &gtb[i];
+    printf("    [%u] ID=%u type=0x%02x firstGroup=%u numGroups=%u protocol=0x%02x "
+           "maxInBW=%u maxOutBW=%u\r\n",
+           i, blk->bGrpTrmBlkID, blk->bGrpTrmBlkType, blk->nGroupTrm, blk->nNumGroupTrm,
+           blk->bMIDIProtocol, blk->wMaxInputBandwidth, blk->wMaxOutputBandwidth);
+  }
+}
+
+// Tracks every currently-mounted UMP interface -- multiple devices can be
+// mounted at once (e.g. several USB MIDI devices behind a hub, see
+// CFG_TUH_UMP/CFG_TUH_DEVICE_MAX in tusb_config.h), so poll_ump_read() and
+// send_test_note() below iterate this table rather than a single "the
+// mounted device" global.
+#define MAX_MOUNTED_UMP CFG_TUH_UMP
+typedef struct { uint8_t daddr; uint8_t itf_num; bool active; } mounted_ump_t;
+static mounted_ump_t s_mounted[MAX_MOUNTED_UMP];
+
+static mounted_ump_t* find_mounted(uint8_t daddr, uint8_t itf_num)
+{
+  for (uint8_t i = 0; i < MAX_MOUNTED_UMP; i++)
+  {
+    if (s_mounted[i].active && s_mounted[i].daddr == daddr && s_mounted[i].itf_num == itf_num) return &s_mounted[i];
+  }
+  return NULL;
+}
+
+// Invoked when a UMP interface finishes enumeration (ump_host.cpp)
+void tuh_ump_mount_cb(uint8_t daddr, uint8_t itf_num)
+{
+  printf("\r\n[UMP] mounted daddr=%u itf_num=%u\r\n", daddr, itf_num);
+  print_gtb_info(daddr, itf_num);
+
+  for (uint8_t i = 0; i < MAX_MOUNTED_UMP; i++)
+  {
+    if (!s_mounted[i].active)
+    {
+      s_mounted[i].daddr    = daddr;
+      s_mounted[i].itf_num  = itf_num;
+      s_mounted[i].active   = true;
+      return;
+    }
+  }
+
+  printf("[UMP] WARNING: mounted-device table full (MAX_MOUNTED_UMP=%u) -- daddr=%u itf_num=%u won't be polled/exercised\r\n",
+         MAX_MOUNTED_UMP, daddr, itf_num);
+}
+
+void tuh_ump_umount_cb(uint8_t daddr, uint8_t itf_num)
+{
+  printf("[UMP] unmounted daddr=%u itf_num=%u\r\n", daddr, itf_num);
+
+  mounted_ump_t* m = find_mounted(daddr, itf_num);
+  if (m) m->active = false;
+}
+
+void tuh_ump_rx_cb(uint8_t daddr, uint8_t itf_num)
+{
+  (void) daddr; (void) itf_num;
+}
+
+//--------------------------------------------------------------------+
+// Generic USB device diagnostics (any attached device, not just MIDI)
+//--------------------------------------------------------------------+
+
+// Invoked when any USB device is mounted (TinyUSB host stack, not UMP-specific) --
+// prints basic identification even for non-MIDI devices, useful to confirm
+// enumeration is happening at all during bring-up.
+void tuh_mount_cb(uint8_t daddr)
+{
+  tusb_desc_device_t desc_device;
+  if (XFER_RESULT_SUCCESS != tuh_descriptor_get_device_sync(daddr, &desc_device, sizeof(desc_device)))
+  {
+    printf("\r\n[USB] device mounted daddr=%u (failed to read device descriptor)\r\n", daddr);
+    return;
+  }
+
+  printf("\r\n[USB] device mounted daddr=%u VID:PID=%04x:%04x bcdUSB=0x%04x bcdDevice=0x%04x "
+         "class=%u/%u/%u\r\n",
+         daddr, desc_device.idVendor, desc_device.idProduct, desc_device.bcdUSB, desc_device.bcdDevice,
+         desc_device.bDeviceClass, desc_device.bDeviceSubClass, desc_device.bDeviceProtocol);
+
+  print_string_desc(daddr, desc_device.iManufacturer, "Manufacturer");
+  print_string_desc(daddr, desc_device.iProduct, "Product");
+  print_string_desc(daddr, desc_device.iSerialNumber, "Serial Number");
+}
+
+void tuh_umount_cb(uint8_t daddr)
+{
+  printf("[USB] device removed daddr=%u\r\n", daddr);
+}
+
+//--------------------------------------------------------------------+
+// Pull decoded UMP words via the real FIFO-backed tuh_ump_read_ntoh() API,
+// and inject a test Note On/Off every second via tuh_ump_write_hton() to
+// exercise the write/TX path too -- both alt settings.
+//--------------------------------------------------------------------+
+
+// Number of 32-bit words in a UMP message of the given Message Type (bits
+// 31:28 of its first word), per the UMP spec -- e.g. MIDI 2.0 Channel Voice
+// (type 4) is always 2 words. Mirrors ump_host.cpp's umph_write_impl() word-
+// count switch.
+static uint8_t ump_mt_word_count(uint32_t mt)
+{
+  switch (mt)
+  {
+    case 0x0: case 0x1: case 0x2: case 0x6: case 0x7: return 1;
+    case 0x3: case 0x4: case 0x8: case 0x9: case 0xA: return 2;
+    case 0xB: case 0xC:                                return 3;
+    case 0x5: case 0xD: case 0xE: case 0xF:            return 4;
+    default:                                            return 1;
+  }
+}
+
+static void poll_ump_read_one(uint8_t daddr, uint8_t itf_num)
+{
+  uint32_t words[16];
+  uint16_t count = tuh_ump_read_ntoh(daddr, itf_num, words, TU_ARRAY_SIZE(words));
+  uint16_t i = 0;
+  while (i < count)
+  {
+    unsigned long const mt = (unsigned long) (words[i] >> 28);
+    printf("[UMP daddr=%u itf=%u] read word: 0x%08lx (MT=0x%lx group=%lu)\r\n",
+           daddr, itf_num, (unsigned long) words[i], mt, (unsigned long) ((words[i] >> 24) & 0xF));
+    i++;
+
+    // Remaining words of this same multi-word message are payload/data, not
+    // independent UMP words -- their top nibble isn't a Message Type, so
+    // don't mislabel them with a bogus (MT=... group=...) decode.
+    uint8_t remaining = (uint8_t) (ump_mt_word_count((uint32_t) mt) - 1);
+    while (remaining && i < count)
+    {
+      printf("[UMP]            0x%08lx\r\n", (unsigned long) words[i]);
+      i++;
+      remaining--;
+    }
+  }
+}
+
+// Multiple devices can be mounted at once -- poll every one of them each
+// iteration rather than just "the" (most recently mounted) device.
+static void poll_ump_read(void)
+{
+  for (uint8_t i = 0; i < MAX_MOUNTED_UMP; i++)
+  {
+    if (s_mounted[i].active) poll_ump_read_one(s_mounted[i].daddr, s_mounted[i].itf_num);
+  }
+}
+
+static void send_test_note_one(uint8_t daddr, uint8_t itf_num, bool note_on)
+{
+  uint16_t written;
+  if (tuh_ump_alt_setting(daddr, itf_num) == 1)
+  {
+    // UMP MIDI 2.0 Channel Voice Note On/Off, group 0, channel 0, note 60 (middle C)
+    uint32_t ump[2];
+    ump[0] = (0x4u << 28) | (0x0u << 24) | ((note_on ? 0x9u : 0x8u) << 20) | (0x0u << 16) | (60u << 8) | 0x00u;
+    ump[1] = (note_on ? 0x7FFFu : 0x0000u) << 16;
+    written = tuh_ump_write_hton(daddr, itf_num, ump, 2);
+  }
+  else
+  {
+    // UMP MIDI 1.0 Channel Voice (message type 2) Note On/Off, group 0,
+    // channel 0, note 60, velocity 100 -- translated to a legacy USB-MIDI1
+    // CIN packet by the driver's alt-0 write path.
+    uint32_t ump[1];
+    ump[0] = (0x2u << 28) | (0x0u << 24) | ((note_on ? 0x9u : 0x8u) << 20) | (0x0u << 16) | (60u << 8) |
+             (note_on ? 100u : 0u);
+    written = tuh_ump_write_hton(daddr, itf_num, ump, 1);
+  }
+
+  printf("[UMP daddr=%u itf=%u] sent test Note %s (wrote %u words)\r\n",
+         daddr, itf_num, note_on ? "On" : "Off", written);
+}
+
+// Exercise the TX path on every mounted device at once, so a multi-device
+// hub test actually validates write, not just read, on each of them.
+static void send_test_note(bool note_on)
+{
+  for (uint8_t i = 0; i < MAX_MOUNTED_UMP; i++)
+  {
+    if (s_mounted[i].active) send_test_note_one(s_mounted[i].daddr, s_mounted[i].itf_num, note_on);
+  }
+}
+
+int main()
+{
+  stdio_init_all();
+
+  printf("\r\n\r\ntusb_ump_host_demo -- USB Host UMP reference app\r\n");
+  printf("Waiting for a USB MIDI device...\r\n");
+
+  tusb_rhport_init_t host_init = {};
+  host_init.role  = TUSB_ROLE_HOST;
+  host_init.speed = TUSB_SPEED_AUTO;
+  tusb_init(BOARD_TUH_RHPORT, &host_init);
+
+  // RP2040's host controller only notifies TinyUSB of a device via an edge-
+  // triggered connect interrupt -- if a device was already plugged in before
+  // tusb_init() ran, there's no edge to catch and it's silently never
+  // enumerated (this shows up as needing an unplug/replug on cold boot).
+  // Work around it by manually checking connect status once at startup and,
+  // if already connected, injecting the same attach event the IRQ handler
+  // would have fired.
+  if (hcd_port_connect_status(BOARD_TUH_RHPORT))
+  {
+    printf("Device already attached at boot -- forcing enumeration\r\n");
+    hcd_event_device_attach(BOARD_TUH_RHPORT, false);
+  }
+
+  printf("Press SPACE to toggle the periodic test Note On/Off write (starts OFF).\r\n");
+
+  uint32_t last_note_ms = 0;
+  bool note_on_next = true;
+  bool write_enabled = false;
+
+  while (true)
+  {
+    tuh_task();
+    poll_ump_read();
+
+    int c = getchar_timeout_us(0);
+    if (c == ' ')
+    {
+      write_enabled = !write_enabled;
+      printf("[UMP] test Note write %s\r\n", write_enabled ? "ENABLED" : "disabled");
+    }
+
+    if (write_enabled)
+    {
+      uint32_t now = to_ms_since_boot(get_absolute_time());
+      if (now - last_note_ms >= 1000)
+      {
+        last_note_ms = now;
+        send_test_note(note_on_next);
+        note_on_next = !note_on_next;
+      }
+    }
+  }
+
+  return 0;
+}

--- a/examples/tusb_ump_host_demo/src/tusb_config.h
+++ b/examples/tusb_ump_host_demo/src/tusb_config.h
@@ -1,0 +1,176 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ * Copyright (c) 2026 MIDI2.dev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUSB_MCU
+  #error CFG_TUSB_MCU must be defined
+#endif
+
+#ifndef CFG_TUSB_OS
+  #define CFG_TUSB_OS               OPT_OS_NONE
+#endif
+
+// NOTE: this define does nothing on its own -- the SDK's own
+// hw/bsp/rp2040/family.cmake force-injects -DCFG_TUSB_DEBUG=<N> on the
+// compiler command line (via tinyusb_common_base's target_compile_definitions),
+// which wins over this header's #ifndef guard regardless of what's written
+// here. To actually enable verbose logging, configure with `cmake -DLOG=1`
+// (see CFG_TUH_LOG_LEVEL below for why 1, not 2).
+#ifndef CFG_TUSB_DEBUG
+  #define CFG_TUSB_DEBUG            0
+#endif
+
+// Deliberately 1, not the TinyUSB default of 2: hcd_rp2040.c's host-controller
+// driver has TWO hardcoded TU_LOG(2, ...) calls ("Buffer complete"/"Transfer
+// complete") INSIDE the actual USB interrupt handler (hcd_rp2040_irq()), fired
+// on every single low-level USB buffer/packet event -- not just once per
+// enumeration step like everything else. Blocking UART printf from inside
+// that ISR is slow enough to disrupt time-critical USB control-transfer
+// sequencing and can break enumeration (devices stalling silently at Set
+// Configuration's status stage) if CFG_TUSB_DEBUG>=2 is used with
+// `cmake -DLOG=2`. Since TU_LOG(2,...) requires CFG_TUSB_DEBUG>=2 to be
+// anything other than a no-op, capping CFG_TUH_LOG_LEVEL at 1 lets this
+// demo's own app/driver-level messages (TU_LOG_USBH in ump_host.cpp and
+// usbh.c's own enumeration trace -- "Device configured", "opened", mount
+// info, etc.) print via the always-available TU_LOG1 at CFG_TUSB_DEBUG=1,
+// while those two ISR-context calls stay silent (they need level 2, which
+// `-DLOG=1` never reaches). Don't raise CFG_TUSB_DEBUG to 2 without
+// re-verifying enumeration reliability against real hardware first.
+#ifndef CFG_TUH_LOG_LEVEL
+  #define CFG_TUH_LOG_LEVEL         1
+#endif
+
+#ifndef CFG_TUSB_MEM_SECTION
+  #define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+  #define CFG_TUSB_MEM_ALIGN        __attribute__ ((aligned(4)))
+#endif
+
+#ifndef CFG_TUH_MEM_SECTION
+  #define CFG_TUH_MEM_SECTION
+#endif
+
+#ifndef CFG_TUH_MEM_ALIGN
+  #define CFG_TUH_MEM_ALIGN         __attribute__ ((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// HOST CONFIGURATION
+//--------------------------------------------------------------------
+
+#define CFG_TUH_ENABLED             1
+
+// RP2040/RP2350 native USB controller; roothub port 0 for both device and
+// host role (single controller, dual-role). VBUS 5V must be supplied to the
+// downstream port for host mode to work -- see README.md's Hardware section.
+#ifndef BOARD_TUH_RHPORT
+  #define BOARD_TUH_RHPORT          0
+#endif
+
+#ifndef BOARD_TUH_MAX_SPEED
+  #define BOARD_TUH_MAX_SPEED       OPT_MODE_FULL_SPEED
+#endif
+
+#define CFG_TUH_MAX_SPEED           BOARD_TUH_MAX_SPEED
+
+// Size of buffer to hold descriptors and other data used during enumeration.
+// Must be >= the largest attached device's full Configuration Descriptor
+// wTotalLength -- some composite USB MIDI devices (e.g. a keyboard with
+// extra HID controls) report 300+ bytes across several interfaces, which
+// silently fails enumeration (a TU_ASSERT in usbh.c's
+// ENUM_GET_FULL_CONFIG_DESC state) against a smaller buffer.
+#define CFG_TUH_ENUMERATION_BUFSIZE 512
+
+// Hub support: a device may be attached through a hub rather than directly
+// to the root port. With CFG_TUH_HUB == 0, TinyUSB core reserves zero
+// address slots for hub-class devices, so enumeration always fails for any
+// device reporting bDeviceClass == Hub, trips a TU_ASSERT, and leaves dev0
+// stuck "enumerating" -- silently wedging all future attach events until
+// that hub is physically unplugged. RP2040's HCD (hcd_rp2040.c) needs no
+// hub-specific changes for this: it addresses devices flatly by
+// dev_addr/endpoint regardless of topology.
+//
+// Caveat: RP2040's native USB controller is Full-Speed-only hardware (no
+// High-Speed PHY) -- BOARD_TUH_MAX_SPEED above isn't a preference, it's a
+// hardware limit. A High-Speed-capable hub/device falls back to Full Speed
+// against this host per standard USB behavior, and some devices present a
+// materially reduced (or MIDI-less) descriptor set at Full Speed vs. their
+// High-Speed configuration.
+//
+// 3 covers stacked/chained hubs (a hub plugged into another hub's
+// downstream port to fan out beyond one hub's own port count), not just a
+// single hub directly on the root port.
+#define CFG_TUH_HUB                 3
+
+// Up to 10 simultaneously-attached devices -- covers a hub plus headroom
+// for stacked/chained hubs (see CFG_TUH_HUB above), to exercise multiple
+// USB MIDI devices attached at once, not just hub traversal to one device.
+// Hubs themselves draw addresses from the separate CFG_TUH_HUB-sized pool,
+// so they don't count against this.
+#define CFG_TUH_DEVICE_MAX          10
+
+//--------------------------------------------------------------------
+// UMP HOST CLASS DRIVER CONFIGURATION
+//--------------------------------------------------------------------
+
+// NOTE: CFG_TUH_MIDI is intentionally left undefined here. Enabling it
+// would merge the AudioControl + MIDIStreaming interfaces into a single
+// open()/set_config() call during enumeration (see ump_host.cpp's design
+// notes), but TinyUSB core's own usbh.c references AUDIO_SUBCLASS_CONTROL /
+// AUDIO_FUNC_PROTOCOL_CODE_UNDEF under that guard without including
+// class/audio/audio.h itself, which fails to build (confirmed against
+// pico-sdk 2.3.0's vendored TinyUSB -- a gap in TinyUSB core, not this
+// driver). ump_host.cpp's umph_open()/umph_set_config() already handle the
+// unmerged (AC-only-call then MS-call) enumeration shape correctly, so this
+// is not a functional loss, just a simpler/safer config.
+// #define CFG_TUH_MIDI             1
+
+// 2 slots per device (see CFG_TUH_DEVICE_MAX above for the device count
+// this is sized against): some composite devices expose an unrelated
+// AudioControl interface (audio in/out) alongside their MIDI AC+MS pair --
+// ump_host.cpp gives each distinct AC interface its own slot (see
+// alloc_new_itf()/find_pending_ac_itf()) so the unrelated one doesn't
+// clobber the real MIDI interface's state. Sized as 2 * CFG_TUH_DEVICE_MAX
+// so every attached device can hit that worst case simultaneously.
+#define CFG_TUH_UMP                 20
+#define CFG_TUH_UMP_MAX_GTB         8
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/examples/tusb_ump_host_demo/tinyusb_overrides/hcd_rp2040.c
+++ b/examples/tusb_ump_host_demo/tinyusb_overrides/hcd_rp2040.c
@@ -1,0 +1,859 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Double Buffered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ *
+ * ---------------------------------------------------------------------------
+ * MIDI2.dev-vendored copy, patched to fix a real-hardware bug in the stock
+ * driver: a downstream USB device that stops responding mid-control-transfer
+ * (observed with an actual USB MIDI device attached through a hub) produces
+ * a genuine SIE-hardware USB_INTS_ERROR_RX_TIMEOUT_BITS interrupt -- the
+ * hardware's own "device never responded" detection -- but the stock driver
+ * just clears the status bit and does nothing else: no completion is ever
+ * reported up to usbh.c, so the transfer (and the single shared epx control
+ * endpoint every device's control transfers depend on) hangs forever with no
+ * diagnostic output, and no other device can enumerate afterwards either.
+ *
+ * Four related changes, all needed together for a clean recovery when this
+ * happens:
+ *
+ * 1. hcd_rp2040_irq()'s RX_TIMEOUT handling now reports XFER_RESULT_TIMEOUT
+ *    (mirrors the STALL handling just above it), so TinyUSB core's existing
+ *    enumeration retry/give-up logic runs instead of the endpoint being
+ *    stuck forever.
+ * 2. hcd_edpt_abort_xfer() is now a real implementation instead of the stock
+ *    no-op stub -- usbh.c's device-removal/recovery path calls this after
+ *    fix #1 lets it actually run, and leaving it a no-op corrupts hardware
+ *    state (the next transfer on that endpoint hits an assert that's
+ *    stripped under NDEBUG, then panics with "ep NN was already available").
+ * 3. hcd_device_close() now also resets epx (the shared control endpoint)
+ *    if it belonged to the device being closed -- otherwise a device closed
+ *    while epx has an in-flight/claimed transfer for it leaves epx's
+ *    hardware buffer-control register in a stale state that the next
+ *    enumerating device's first control transfer panics against.
+ * 4. A software timeout for epx control transfers, since RP2040 has no
+ *    hardware NAK-count interrupt (SIE_STATUS.NAK_REC exists as a status bit
+ *    but has no corresponding INTR/INTE/INTF/INTS source): a device that
+ *    ACKs the SETUP stage but then NAKs the data-stage IN indefinitely never
+ *    triggers RX_TIMEOUT (a different condition -- "device went silent", not
+ *    "device keeps NAKing") and would otherwise hang forever even with fixes
+ *    1-3 in place. Scoped to epx only, since that's the shared endpoint
+ *    every device's control transfers depend on; bulk/interrupt endpoints
+ *    get their own dedicated hardware slot and aren't affected by this
+ *    class of hang.
+ *
+ * Re-verify this patch still applies (or re-derive it) against
+ * hcd_rp2040_irq() when bumping the pico-sdk/TinyUSB version this example
+ * builds against.
+ * ---------------------------------------------------------------------------
+ */
+
+#include "tusb_option.h"
+
+#if CFG_TUH_ENABLED && (CFG_TUSB_MCU == OPT_MCU_RP2040) && !CFG_TUH_RPI_PIO_USB && !CFG_TUH_MAX3421
+
+#include "pico.h"
+#include "rp2040_usb.h"
+#include "pico/time.h"
+
+//--------------------------------------------------------------------+
+// INCLUDE
+//--------------------------------------------------------------------+
+#include "osal/osal.h"
+
+#include "host/hcd.h"
+#include "host/usbh.h"
+
+// port 0 is native USB port, other is counted as software PIO
+#define RHPORT_NATIVE 0
+
+//--------------------------------------------------------------------+
+// Low level rp2040 controller functions
+//--------------------------------------------------------------------+
+
+#ifndef PICO_USB_HOST_INTERRUPT_ENDPOINTS
+#define PICO_USB_HOST_INTERRUPT_ENDPOINTS (USB_MAX_ENDPOINTS - 1)
+#endif
+static_assert(PICO_USB_HOST_INTERRUPT_ENDPOINTS <= USB_MAX_ENDPOINTS, "");
+
+// Host mode uses one shared endpoint register for non-interrupt endpoint
+static struct hw_endpoint ep_pool[1 + PICO_USB_HOST_INTERRUPT_ENDPOINTS];
+#define epx (ep_pool[0])
+
+// Flags we set by default in sie_ctrl (we add other bits on top)
+enum {
+  SIE_CTRL_BASE = USB_SIE_CTRL_SOF_EN_BITS      | USB_SIE_CTRL_KEEP_ALIVE_EN_BITS |
+                  USB_SIE_CTRL_PULLDOWN_EN_BITS | USB_SIE_CTRL_EP0_INT_1BUF_BITS
+};
+
+static struct hw_endpoint *get_dev_ep(uint8_t dev_addr, uint8_t ep_addr)
+{
+  uint8_t num = tu_edpt_number(ep_addr);
+  if ( num == 0 ) return &epx;
+
+  for ( uint32_t i = 1; i < TU_ARRAY_SIZE(ep_pool); i++ )
+  {
+    struct hw_endpoint *ep = &ep_pool[i];
+    if ( ep->configured && (ep->dev_addr == dev_addr) && (ep->ep_addr == ep_addr) ) return ep;
+  }
+
+  return NULL;
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint8_t dev_speed(void)
+{
+  return (usb_hw->sie_status & USB_SIE_STATUS_SPEED_BITS) >> USB_SIE_STATUS_SPEED_LSB;
+}
+
+TU_ATTR_ALWAYS_INLINE static inline bool need_pre(uint8_t dev_addr)
+{
+  // If this device is different to the speed of the root device
+  // (i.e. is a low speed device on a full speed hub) then need pre
+  return hcd_port_speed_get(0) != tuh_speed_get(dev_addr);
+}
+
+static void __tusb_irq_path_func(hw_xfer_complete)(struct hw_endpoint *ep, xfer_result_t xfer_result);
+
+// epx NAK-forever software timeout (see file header, fix #4). generation is
+// bumped every time epx is armed or completed, so a stale alarm firing
+// after the transfer it was meant for has already completed (by any path --
+// success, STALL, RX_TIMEOUT) can recognize itself as stale and do nothing,
+// instead of racing hw_xfer_complete() a second time for the same struct.
+#ifndef TUSB_UMP_EPX_XFER_TIMEOUT_MS
+#define TUSB_UMP_EPX_XFER_TIMEOUT_MS 500
+#endif
+static volatile uint32_t s_epx_xfer_generation;
+static alarm_id_t s_epx_timeout_alarm;
+
+static int64_t __tusb_irq_path_func(_epx_xfer_timeout_cb)(alarm_id_t id, void *user_data)
+{
+  uint32_t const expected_generation = (uint32_t) (uintptr_t) user_data;
+
+  uint32_t ints = save_and_disable_interrupts();
+  bool const stale = (id != s_epx_timeout_alarm) ||
+                      (expected_generation != s_epx_xfer_generation) ||
+                      !epx.active;
+  if ( !stale )
+  {
+    s_epx_timeout_alarm = 0;
+    // Same defense-in-depth as the RX_TIMEOUT handler: a BUFF_STATUS bit
+    // for epx could already be latched (device finally answered right as
+    // this alarm fired). Discard it -- we're declaring this transfer dead
+    // either way, and hw_handle_buff_status() must not run against a
+    // struct hw_xfer_complete() is about to reset.
+    usb_hw_clear->buf_status = 0b1;
+  }
+  restore_interrupts(ints);
+
+  if ( !stale )
+  {
+    TU_LOG(1, "tusb_ump: epx control xfer NAK-timeout (dev %u ep 0x%02x)\n", epx.dev_addr, epx.ep_addr);
+    hw_xfer_complete(&epx, XFER_RESULT_TIMEOUT);
+  }
+
+  return 0; // one-shot, don't reschedule
+}
+
+// Call after arming any new epx transfer (control OUT/IN or SETUP).
+static void _epx_xfer_timeout_arm(void)
+{
+  uint32_t ints = save_and_disable_interrupts();
+  uint32_t const generation = ++s_epx_xfer_generation;
+  if ( s_epx_timeout_alarm )
+  {
+    cancel_alarm(s_epx_timeout_alarm);
+  }
+  s_epx_timeout_alarm = add_alarm_in_ms(TUSB_UMP_EPX_XFER_TIMEOUT_MS, _epx_xfer_timeout_cb,
+                                         (void *) (uintptr_t) generation, true);
+  restore_interrupts(ints);
+}
+
+// Call whenever epx transitions out of "in flight" by any path.
+static void _epx_xfer_timeout_cancel(void)
+{
+  uint32_t ints = save_and_disable_interrupts();
+  ++s_epx_xfer_generation;
+  if ( s_epx_timeout_alarm )
+  {
+    cancel_alarm(s_epx_timeout_alarm);
+    s_epx_timeout_alarm = 0;
+  }
+  restore_interrupts(ints);
+}
+
+static void __tusb_irq_path_func(hw_xfer_complete)(struct hw_endpoint *ep, xfer_result_t xfer_result)
+{
+  if ( ep == &epx )
+  {
+    _epx_xfer_timeout_cancel();
+  }
+
+  // Mark transfer as done before we tell the tinyusb stack
+  uint8_t dev_addr = ep->dev_addr;
+  uint8_t ep_addr = ep->ep_addr;
+  uint xferred_len = ep->xferred_len;
+  hw_endpoint_reset_transfer(ep);
+  hcd_event_xfer_complete(dev_addr, ep_addr, xferred_len, xfer_result, true);
+}
+
+static void __tusb_irq_path_func(_handle_buff_status_bit)(uint bit, struct hw_endpoint *ep)
+{
+  usb_hw_clear->buf_status = bit;
+
+  // Defense in depth alongside the RX_TIMEOUT-time buf_status clear above --
+  // if a stale buffer-status bit for this endpoint still arrives after it's
+  // already been reset (e.g. by a timeout/stall/abort),
+  // hw_endpoint_xfer_continue() calls panic() unconditionally (not an
+  // assert() -- NDEBUG does not strip it) when !ep->active. Skip the call
+  // instead of crashing; the transfer this bit belonged to has already been
+  // completed/reported by whatever reset ep->active.
+  if (!ep->active) {
+    return;
+  }
+  assert(ep->active);
+  bool done = hw_endpoint_xfer_continue(ep);
+  if ( done )
+  {
+    hw_xfer_complete(ep, XFER_RESULT_SUCCESS);
+  }
+}
+
+static void __tusb_irq_path_func(hw_handle_buff_status)(void)
+{
+  uint32_t remaining_buffers = usb_hw->buf_status;
+  pico_trace("buf_status 0x%08lx\n", remaining_buffers);
+
+  // Check EPX first
+  uint bit = 0b1;
+  if ( remaining_buffers & bit )
+  {
+    remaining_buffers &= ~bit;
+    struct hw_endpoint * ep = &epx;
+
+    uint32_t ep_ctrl = *ep->endpoint_control;
+    if ( ep_ctrl & EP_CTRL_DOUBLE_BUFFERED_BITS )
+    {
+      TU_LOG(3, "Double Buffered: ");
+    }
+    else
+    {
+      TU_LOG(3, "Single Buffered: ");
+    }
+    TU_LOG_HEX(3, ep_ctrl);
+
+    _handle_buff_status_bit(bit, ep);
+  }
+
+  // Check "interrupt" (asynchronous) endpoints for both IN and OUT
+  for ( uint i = 1; i <= USB_HOST_INTERRUPT_ENDPOINTS && remaining_buffers; i++ )
+  {
+    // EPX is bit 0 & 1
+    // IEP1 IN  is bit 2
+    // IEP1 OUT is bit 3
+    // IEP2 IN  is bit 4
+    // IEP2 OUT is bit 5
+    // IEP3 IN  is bit 6
+    // IEP3 OUT is bit 7
+    // etc
+    for ( uint j = 0; j < 2; j++ )
+    {
+      bit = 1 << (i * 2 + j);
+      if ( remaining_buffers & bit )
+      {
+        remaining_buffers &= ~bit;
+        _handle_buff_status_bit(bit, &ep_pool[i]);
+      }
+    }
+  }
+
+  if ( remaining_buffers )
+  {
+    panic("Unhandled buffer %d\n", remaining_buffers);
+  }
+}
+
+static void __tusb_irq_path_func(hw_trans_complete)(void)
+{
+  if (usb_hw->sie_ctrl & USB_SIE_CTRL_SEND_SETUP_BITS)
+  {
+    pico_trace("Sent setup packet\n");
+    struct hw_endpoint *ep = &epx;
+    assert(ep->active);
+    // Set transferred length to 8 for a setup packet
+    ep->xferred_len = 8;
+    hw_xfer_complete(ep, XFER_RESULT_SUCCESS);
+  }
+  else
+  {
+    // Don't care. Will handle this in buff status
+    return;
+  }
+}
+
+static void __tusb_irq_path_func(hcd_rp2040_irq)(void)
+{
+  uint32_t status = usb_hw->ints;
+  uint32_t handled = 0;
+
+  if ( status & USB_INTS_HOST_CONN_DIS_BITS )
+  {
+    handled |= USB_INTS_HOST_CONN_DIS_BITS;
+
+    if ( dev_speed() )
+    {
+      hcd_event_device_attach(RHPORT_NATIVE, true);
+    }
+    else
+    {
+      hcd_event_device_remove(RHPORT_NATIVE, true);
+    }
+
+    // Clear speed change interrupt
+    usb_hw_clear->sie_status = USB_SIE_STATUS_SPEED_BITS;
+  }
+
+  if ( status & USB_INTS_STALL_BITS )
+  {
+    // We have rx'd a stall from the device
+    // NOTE THIS SHOULD HAVE PRIORITY OVER BUFF_STATUS
+    // AND TRANS_COMPLETE as the stall is an alternative response
+    // to one of those events
+    pico_trace("Stall REC\n");
+    handled |= USB_INTS_STALL_BITS;
+    usb_hw_clear->sie_status = USB_SIE_STATUS_STALL_REC_BITS;
+    hw_xfer_complete(&epx, XFER_RESULT_STALLED);
+  }
+
+  if ( status & USB_INTS_BUFF_STATUS_BITS )
+  {
+    handled |= USB_INTS_BUFF_STATUS_BITS;
+    TU_LOG(2, "Buffer complete\r\n");
+    hw_handle_buff_status();
+  }
+
+  if ( status & USB_INTS_TRANS_COMPLETE_BITS )
+  {
+    handled |= USB_INTS_TRANS_COMPLETE_BITS;
+    usb_hw_clear->sie_status = USB_SIE_STATUS_TRANS_COMPLETE_BITS;
+    TU_LOG(2, "Transfer complete\r\n");
+    hw_trans_complete();
+  }
+
+  if ( status & USB_INTS_ERROR_RX_TIMEOUT_BITS )
+  {
+    handled |= USB_INTS_ERROR_RX_TIMEOUT_BITS;
+    usb_hw_clear->sie_status = USB_SIE_STATUS_RX_TIMEOUT_BITS;
+
+    // Fix #1 (see file header): report the hardware's own timeout detection
+    // instead of silently discarding it, so a device that stops responding
+    // produces a visible retry/give-up instead of a permanent, silent,
+    // system-wide hang. Guard on epx.active in case the bit fires with
+    // nothing actually in flight.
+    if (epx.active) {
+      // A BUFF_STATUS interrupt for epx (bit 0) can be separately latched
+      // by hardware for the same transfer that's timing out, and arrive in
+      // a LATER, separate hcd_rp2040_irq() invocation after this one has
+      // already reset epx below. hw_handle_buff_status() would then find
+      // ep->active already false and panic ("Can't continue xfer on
+      // inactive ep") -- confirmed on hardware. Clear any pending epx
+      // buffer-status bit now so a stale completion can't be dispatched
+      // against a struct we're about to reset. (bit 0 only -- must not
+      // clear other endpoints' legitimately pending bits here.)
+      usb_hw_clear->buf_status = 0b1;
+      hw_xfer_complete(&epx, XFER_RESULT_TIMEOUT);
+    }
+  }
+
+  if ( status & USB_INTS_ERROR_DATA_SEQ_BITS )
+  {
+    usb_hw_clear->sie_status = USB_SIE_STATUS_DATA_SEQ_ERROR_BITS;
+    TU_LOG(3, "  Seq Error: [0] = 0x%04u  [1] = 0x%04x\r\n",
+           tu_u32_low16(*epx.buffer_control),
+           tu_u32_high16(*epx.buffer_control));
+    panic("Data Seq Error \n");
+  }
+
+  if ( status ^ handled )
+  {
+    panic("Unhandled IRQ 0x%x\n", (uint) (status ^ handled));
+  }
+}
+
+void __tusb_irq_path_func(hcd_int_handler)(uint8_t rhport, bool in_isr) {
+  (void) rhport;
+  (void) in_isr;
+  hcd_rp2040_irq();
+}
+
+static struct hw_endpoint *_next_free_interrupt_ep(void)
+{
+  struct hw_endpoint * ep = NULL;
+  for ( uint i = 1; i < TU_ARRAY_SIZE(ep_pool); i++ )
+  {
+    ep = &ep_pool[i];
+    if ( !ep->configured )
+    {
+      // Will be configured by _hw_endpoint_init / _hw_endpoint_allocate
+      ep->interrupt_num = (uint8_t) (i - 1);
+      return ep;
+    }
+  }
+  return ep;
+}
+
+static struct hw_endpoint *_hw_endpoint_allocate(uint8_t transfer_type)
+{
+  struct hw_endpoint * ep = NULL;
+
+  if ( transfer_type != TUSB_XFER_CONTROL )
+  {
+    // Note: even though datasheet name these "Interrupt" endpoints. These are actually
+    // "Asynchronous" endpoints and can be used for other type such as: Bulk  (ISO need confirmation)
+    ep = _next_free_interrupt_ep();
+    pico_info("Allocate %s ep %d\n", tu_edpt_type_str(transfer_type), ep->interrupt_num);
+    assert(ep);
+    ep->buffer_control = &usbh_dpram->int_ep_buffer_ctrl[ep->interrupt_num].ctrl;
+    ep->endpoint_control = &usbh_dpram->int_ep_ctrl[ep->interrupt_num].ctrl;
+    // 0 for epx (double buffered): TODO increase to 1024 for ISO
+    // 2x64 for intep0
+    // 3x64 for intep1
+    // etc
+    ep->hw_data_buf = &usbh_dpram->epx_data[64 * (ep->interrupt_num + 2)];
+  }
+  else
+  {
+    ep = &epx;
+    ep->buffer_control = &usbh_dpram->epx_buf_ctrl;
+    ep->endpoint_control = &usbh_dpram->epx_ctrl;
+    ep->hw_data_buf = &usbh_dpram->epx_data[0];
+  }
+
+  return ep;
+}
+
+static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t dev_addr, uint8_t ep_addr, uint16_t wMaxPacketSize, uint8_t transfer_type, uint8_t bmInterval)
+{
+  // Already has data buffer, endpoint control, and buffer control allocated at this point
+  assert(ep->endpoint_control);
+  assert(ep->buffer_control);
+  assert(ep->hw_data_buf);
+
+  uint8_t const num = tu_edpt_number(ep_addr);
+  tusb_dir_t const dir = tu_edpt_dir(ep_addr);
+
+  ep->ep_addr = ep_addr;
+  ep->dev_addr = dev_addr;
+
+  // For host, IN to host == RX, anything else rx == false
+  ep->rx = (dir == TUSB_DIR_IN);
+
+  // Response to a setup packet on EP0 starts with pid of 1
+  ep->next_pid = (num == 0 ? 1u : 0u);
+  ep->wMaxPacketSize = wMaxPacketSize;
+  ep->transfer_type = transfer_type;
+
+  pico_trace("hw_endpoint_init dev %d ep %02X xfer %d\n", ep->dev_addr, ep->ep_addr, ep->transfer_type);
+  pico_trace("dev %d ep %02X setup buffer @ 0x%p\n", ep->dev_addr, ep->ep_addr, ep->hw_data_buf);
+  uint dpram_offset = hw_data_offset(ep->hw_data_buf);
+  // Bits 0-5 should be 0
+  assert(!(dpram_offset & 0b111111));
+
+  // Fill in endpoint control register with buffer offset
+  uint32_t ep_reg = EP_CTRL_ENABLE_BITS
+                    | EP_CTRL_INTERRUPT_PER_BUFFER
+                    | (ep->transfer_type << EP_CTRL_BUFFER_TYPE_LSB)
+                    | dpram_offset;
+  if ( bmInterval )
+  {
+    ep_reg |= (uint32_t) ((bmInterval - 1) << EP_CTRL_HOST_INTERRUPT_INTERVAL_LSB);
+  }
+  *ep->endpoint_control = ep_reg;
+  pico_trace("endpoint control (0x%p) <- 0x%lx\n", ep->endpoint_control, ep_reg);
+  ep->configured = true;
+
+  if ( ep != &epx )
+  {
+    // Endpoint has its own addr_endp and interrupt bits to be setup!
+    // This is an interrupt/async endpoint. so need to set up ADDR_ENDP register with:
+    // - device address
+    // - endpoint number / direction
+    // - preamble
+    uint32_t reg = (uint32_t) (dev_addr | (num << USB_ADDR_ENDP1_ENDPOINT_LSB));
+
+    if ( dir == TUSB_DIR_OUT )
+    {
+      reg |= USB_ADDR_ENDP1_INTEP_DIR_BITS;
+    }
+
+    if ( need_pre(dev_addr) )
+    {
+      reg |= USB_ADDR_ENDP1_INTEP_PREAMBLE_BITS;
+    }
+    usb_hw->int_ep_addr_ctrl[ep->interrupt_num] = reg;
+
+    // Finally, enable interrupt that endpoint
+    usb_hw_set->int_ep_ctrl = 1 << (ep->interrupt_num + 1);
+
+    // If it's an interrupt endpoint we need to set up the buffer control
+    // register
+  }
+}
+
+//--------------------------------------------------------------------+
+// HCD API
+//--------------------------------------------------------------------+
+bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rhport;
+  (void) rh_init;
+  pico_trace("hcd_init %d\n", rhport);
+  assert(rhport == 0);
+
+  // Reset any previous state
+  rp2040_usb_init();
+
+  // Force VBUS detect to always present, for now we assume vbus is always provided (without using VBUS En)
+  usb_hw->pwr = USB_USB_PWR_VBUS_DETECT_BITS | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
+
+  // Remove shared irq if it was previously added so as not to fill up shared irq slots
+  irq_remove_handler(USBCTRL_IRQ, hcd_rp2040_irq);
+
+  irq_add_shared_handler(USBCTRL_IRQ, hcd_rp2040_irq, PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY);
+
+  // clear epx and interrupt eps
+  memset(&ep_pool, 0, sizeof(ep_pool));
+
+  // Enable in host mode with SOF / Keep alive on
+  usb_hw->main_ctrl = USB_MAIN_CTRL_CONTROLLER_EN_BITS | USB_MAIN_CTRL_HOST_NDEVICE_BITS;
+  usb_hw->sie_ctrl = SIE_CTRL_BASE;
+  usb_hw->inte = USB_INTE_BUFF_STATUS_BITS      |
+                 USB_INTE_HOST_CONN_DIS_BITS    |
+                 USB_INTE_HOST_RESUME_BITS      |
+                 USB_INTE_STALL_BITS            |
+                 USB_INTE_TRANS_COMPLETE_BITS   |
+                 USB_INTE_ERROR_RX_TIMEOUT_BITS |
+                 USB_INTE_ERROR_DATA_SEQ_BITS   ;
+
+  return true;
+}
+
+bool hcd_deinit(uint8_t rhport) {
+  (void) rhport;
+
+  irq_remove_handler(USBCTRL_IRQ, hcd_rp2040_irq);
+  reset_block(RESETS_RESET_USBCTRL_BITS);
+  unreset_block_wait(RESETS_RESET_USBCTRL_BITS);
+
+  return true;
+}
+
+void hcd_port_reset(uint8_t rhport)
+{
+  (void) rhport;
+  pico_trace("hcd_port_reset\n");
+  assert(rhport == 0);
+  // TODO: Nothing to do here yet. Perhaps need to reset some state?
+}
+
+void hcd_port_reset_end(uint8_t rhport)
+{
+  (void) rhport;
+}
+
+bool hcd_port_connect_status(uint8_t rhport)
+{
+  (void) rhport;
+  pico_trace("hcd_port_connect_status\n");
+  assert(rhport == 0);
+  return usb_hw->sie_status & USB_SIE_STATUS_SPEED_BITS;
+}
+
+tusb_speed_t hcd_port_speed_get(uint8_t rhport)
+{
+  (void) rhport;
+  assert(rhport == 0);
+
+  // TODO: Should enumval this register
+  switch ( dev_speed() )
+  {
+    case 1:
+      return TUSB_SPEED_LOW;
+    case 2:
+      return TUSB_SPEED_FULL;
+    default:
+      panic("Invalid speed\n");
+      // return TUSB_SPEED_INVALID;
+  }
+}
+
+// Close all opened endpoint belong to this device
+void hcd_device_close(uint8_t rhport, uint8_t dev_addr)
+{
+  pico_trace("hcd_device_close %d\n", dev_addr);
+  (void) rhport;
+
+  if (dev_addr == 0) return;
+
+  // Fix #3 (see file header): epx (ep_pool[0]) is the single hardware
+  // control endpoint shared by EVERY device's control transfers (see
+  // get_dev_ep(): endpoint number 0 always maps to &epx). The loop below
+  // only walks indices 1..N (the per-device interrupt endpoints), so if
+  // this device is disconnected while epx still has an in-flight/claimed
+  // transfer for it, epx's hardware buffer-control register keeps whatever
+  // state that transfer left (e.g. USB_BUF_CTRL_AVAIL still set). The next
+  // control transfer issued through epx -- e.g. a subsequently enumerating
+  // device's very first Get Device Descriptor -- then hits rp2040_usb.c's
+  // "ep NN was already available" panic. Confirmed on hardware: this fired
+  // for a hub device closed right after its own Set Configuration timed
+  // out, on the very next dev0 attach.
+  if (epx.dev_addr == dev_addr) {
+    // Also cancel any pending NAK-timeout alarm for epx -- it's being reset
+    // out from under whatever transfer it was tracking, same as the
+    // RX_TIMEOUT/abort paths below.
+    _epx_xfer_timeout_cancel();
+    *epx.endpoint_control = 0;
+    *epx.buffer_control = 0;
+    hw_endpoint_reset_transfer(&epx);
+  }
+
+  for (size_t i = 1; i < TU_ARRAY_SIZE(ep_pool); i++)
+  {
+    hw_endpoint_t* ep = &ep_pool[i];
+
+    if (ep->dev_addr == dev_addr && ep->configured)
+    {
+      // in case it is an interrupt endpoint, disable it
+      usb_hw_clear->int_ep_ctrl = (1 << (ep->interrupt_num + 1));
+      usb_hw->int_ep_addr_ctrl[ep->interrupt_num] = 0;
+
+      // unconfigure the endpoint
+      ep->configured = false;
+      *ep->endpoint_control = 0;
+      *ep->buffer_control = 0;
+      hw_endpoint_reset_transfer(ep);
+    }
+  }
+}
+
+uint32_t hcd_frame_number(uint8_t rhport)
+{
+  (void) rhport;
+  return usb_hw->sof_rd;
+}
+
+void hcd_int_enable(uint8_t rhport)
+{
+  (void) rhport;
+  assert(rhport == 0);
+  irq_set_enabled(USBCTRL_IRQ, true);
+}
+
+void hcd_int_disable(uint8_t rhport)
+{
+  (void) rhport;
+  // todo we should check this is disabling from the correct core; note currently this is never called
+  assert(rhport == 0);
+  irq_set_enabled(USBCTRL_IRQ, false);
+}
+
+//--------------------------------------------------------------------+
+// Endpoint API
+//--------------------------------------------------------------------+
+
+bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * ep_desc)
+{
+  (void) rhport;
+
+  pico_trace("hcd_edpt_open dev_addr %d, ep_addr %d\n", dev_addr, ep_desc->bEndpointAddress);
+
+  // Allocated differently based on if it's an interrupt endpoint or not
+  struct hw_endpoint *ep = _hw_endpoint_allocate(ep_desc->bmAttributes.xfer);
+  TU_ASSERT(ep);
+
+  _hw_endpoint_init(ep,
+                    dev_addr,
+                    ep_desc->bEndpointAddress,
+                    tu_edpt_packet_size(ep_desc),
+                    ep_desc->bmAttributes.xfer,
+                    ep_desc->bInterval);
+
+  return true;
+}
+
+bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t buflen)
+{
+  (void) rhport;
+
+  pico_trace("hcd_edpt_xfer dev_addr %d, ep_addr 0x%x, len %d\n", dev_addr, ep_addr, buflen);
+
+  uint8_t const ep_num = tu_edpt_number(ep_addr);
+  tusb_dir_t const ep_dir = tu_edpt_dir(ep_addr);
+
+  // Get appropriate ep. Either EPX or interrupt endpoint
+  struct hw_endpoint *ep = get_dev_ep(dev_addr, ep_addr);
+
+  TU_ASSERT(ep);
+
+  // EP should be inactive
+  assert(!ep->active);
+
+  // Control endpoint can change direction 0x00 <-> 0x80
+  if ( ep_addr != ep->ep_addr )
+  {
+    assert(ep_num == 0);
+
+    // Direction has flipped on endpoint control so re init it but with same properties
+    _hw_endpoint_init(ep, dev_addr, ep_addr, ep->wMaxPacketSize, ep->transfer_type, 0);
+  }
+
+  // If a normal transfer (non-interrupt) then initiate using
+  // sie ctrl registers. Otherwise interrupt ep registers should
+  // already be configured
+  if ( ep == &epx )
+  {
+    hw_endpoint_xfer_start(ep, buffer, buflen);
+
+    // That has set up buffer control, endpoint control etc
+    // for host we have to initiate the transfer
+    usb_hw->dev_addr_ctrl = (uint32_t) (dev_addr | (ep_num << USB_ADDR_ENDP_ENDPOINT_LSB));
+
+    uint32_t flags = USB_SIE_CTRL_START_TRANS_BITS | SIE_CTRL_BASE |
+                     (ep_dir ? USB_SIE_CTRL_RECEIVE_DATA_BITS : USB_SIE_CTRL_SEND_DATA_BITS) |
+                     (need_pre(dev_addr) ? USB_SIE_CTRL_PREAMBLE_EN_BITS : 0);
+    // START_TRANS bit on SIE_CTRL seems to exhibit the same behavior as the AVAILABLE bit
+    // described in RP2040 Datasheet, release 2.1, section "4.1.2.5.1. Concurrent access".
+    // We write everything except the START_TRANS bit first, then wait some cycles.
+    usb_hw->sie_ctrl = flags & ~USB_SIE_CTRL_START_TRANS_BITS;
+    busy_wait_at_least_cycles(12);
+    usb_hw->sie_ctrl = flags;
+
+    // Fix #4 (see file header): arm the NAK-forever software timeout. Only
+    // epx needs this -- bulk endpoints (ep_pool[1..]) have their own
+    // dedicated hardware slot.
+    _epx_xfer_timeout_arm();
+  }else
+  {
+    hw_endpoint_xfer_start(ep, buffer, buflen);
+  }
+
+  return true;
+}
+
+bool hcd_edpt_abort_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr) {
+  (void) rhport;
+
+  // Fix #2 (see file header, linked to fix #1): fixing RX_TIMEOUT visibility
+  // alone lets usbh.c's device-removal/recovery path actually run instead
+  // of hanging forever, but that path calls tuh_edpt_abort_xfer() -> this
+  // function, and its caller (usbh.c) always clears its OWN software
+  // bookkeeping regardless of this function's return value. Left as a no-op
+  // stub, the underlying hw_endpoint struct never matches what usbh.c
+  // believes, and the very next hcd_edpt_xfer() on it hits
+  // assert(!ep->active) -- stripped under NDEBUG in a Release build -- and
+  // silently corrupts hardware state, producing "*** PANIC *** ep 80 was
+  // already available" on the next attach. The two fixes are needed
+  // together for the device-removal recovery path to actually complete
+  // cleanly.
+  //
+  // This resets the struct's software-side tracking to match what usbh.c
+  // already believes. It does not attempt to cancel an in-flight SIE
+  // hardware transaction at the register level (no verified safe sequence
+  // for that was found) -- best-effort improvement over the prior no-op,
+  // not a complete fix.
+  struct hw_endpoint *ep = get_dev_ep(dev_addr, ep_addr);
+  if (!ep) return false;
+
+  // Cancel any pending NAK-timeout alarm if this is epx -- it's about to be
+  // forced idle out from under whatever it was tracking.
+  if (ep == &epx) {
+    _epx_xfer_timeout_cancel();
+  }
+
+  // Also clear the actual hardware buffer-control register, not just the
+  // software struct -- see the file-header comment and hcd_device_close()
+  // above for why: leaving USB_BUF_CTRL_AVAIL set on the real register is
+  // what actually causes rp2040_usb.c's "ep NN was already available"
+  // panic on the next transfer, and hw_endpoint_reset_transfer() alone
+  // does not touch it.
+  *ep->endpoint_control = 0;
+  *ep->buffer_control = 0;
+  hw_endpoint_reset_transfer(ep);
+  return true;
+}
+
+bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8])
+{
+  (void) rhport;
+
+  // Copy data into setup packet buffer
+  for ( uint8_t i = 0; i < 8; i++ )
+  {
+    usbh_dpram->setup_packet[i] = setup_packet[i];
+  }
+
+  // Configure EP0 struct with setup info for the trans complete
+  struct hw_endpoint * ep = _hw_endpoint_allocate(0);
+  TU_ASSERT(ep);
+
+  // EPX should be inactive
+  assert(!ep->active);
+
+  // EP0 out
+  _hw_endpoint_init(ep, dev_addr, 0x00, ep->wMaxPacketSize, 0, 0);
+  assert(ep->configured);
+
+  ep->remaining_len = 8;
+  ep->active = true;
+
+  // Set device address
+  usb_hw->dev_addr_ctrl = dev_addr;
+
+  // Set pre if we are a low speed device on full speed hub
+  uint32_t const flags = SIE_CTRL_BASE | USB_SIE_CTRL_SEND_SETUP_BITS | USB_SIE_CTRL_START_TRANS_BITS |
+                         (need_pre(dev_addr) ? USB_SIE_CTRL_PREAMBLE_EN_BITS : 0);
+
+  // START_TRANS bit on SIE_CTRL seems to exhibit the same behavior as the AVAILABLE bit
+  // described in RP2040 Datasheet, release 2.1, section "4.1.2.5.1. Concurrent access".
+  // We write everything except the START_TRANS bit first, then wait some cycles.
+  usb_hw->sie_ctrl = flags & ~USB_SIE_CTRL_START_TRANS_BITS;
+  busy_wait_at_least_cycles(12);
+  usb_hw->sie_ctrl = flags;
+
+  // Fix #4 (see file header): SETUP stage also goes through epx and can be
+  // the stage that never gets its status/data-in response -- arm the same
+  // timeout here too, not just in hcd_edpt_xfer().
+  _epx_xfer_timeout_arm();
+
+  return true;
+}
+
+bool hcd_edpt_clear_stall(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr) {
+  (void) rhport;
+  (void) dev_addr;
+  (void) ep_addr;
+
+  panic("hcd_clear_stall");
+  // return true;
+}
+
+#endif


### PR DESCRIPTION
## Summary
- New self-contained pico-sdk example, `examples/tusb_ump_host_demo/`, demonstrating `ump_host` (the v0.7.0 USB Host UMP class driver) -- mirrors `examples/tusb_ump_lb`'s structure and README style, but for host role.
- Prints device identification (VID/PID, manufacturer/product/serial) for any attached USB device, plus Group Terminal Block info once a UMP interface mounts.
- Decodes and prints every incoming UMP word on either alt setting (native UMP or legacy USB-MIDI 1.0).
- Injects a test Note On/Off once a second (SPACE to toggle) to exercise the write path without needing a second app sending MIDI.
- Includes a vendored, patched `hcd_rp2040.c` fixing a real hardware bug (a downstream device that stops responding mid-control-transfer otherwise hangs the shared control endpoint forever) -- see that file's own header comment for the four related fixes.

## Validation
Verified end-to-end on real ProtoZOA hardware (RP2040, USB HOST role) against a physical USB MIDI 2.0 device (OAKTONE Oakboard Mini): device enumeration, live UMP event decoding, and test-note injection all confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)