### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "tusb_ump",
-  "version": "0.1.0",
+  "version": "0.7.1",
   "description": "USB MIDI 2.0 UMP device and host drivers for TinyUSB (midi2-dev/tusb_ump)",
   "keywords": ["midi", "midi2", "ump", "usb", "tinyusb"],
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=tusb_ump
-version=0.1.0
+version=0.7.1
 author=
 maintainer=
 sentence=USB MIDI 2.0 UMP device and host drivers for TinyUSB


### PR DESCRIPTION
Point release for the new `tusb_ump_host_demo` example (#27). Also fixes `library.json`/`library.properties`' version field, stuck at 0.1.0 since the initial release and never kept in sync with the actual git-tag release history.