### PR TITLE
Bump version to 0.7.2

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "tusb_ump",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "USB MIDI 2.0 UMP device and host drivers for TinyUSB (midi2-dev/tusb_ump)",
   "keywords": ["midi", "midi2", "ump", "usb", "tinyusb"],
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=tusb_ump
-version=0.7.1
+version=0.7.2
 author=
 maintainer=
 sentence=USB MIDI 2.0 UMP device and host drivers for TinyUSB


### PR DESCRIPTION
Keeps library.json/library.properties' version field in sync with the v0.7.2 tag (Host API documentation).